### PR TITLE
Add Itip as a dependency

### DIFF
--- a/.horde.yml
+++ b/.horde.yml
@@ -60,6 +60,7 @@ dependencies:
       pear.horde.org/Horde_History: ^2.1
       pear.horde.org/Horde_Icalendar: ^2
       pear.horde.org/Horde_Image: ^2
+      pear.horde.org/Horde_Itip: ^2
       pear.horde.org/Horde_Lock: ^2
       pear.horde.org/Horde_LoginTasks: ^2
       pear.horde.org/Horde_Mail: ^2

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "pear-pear.horde.org/Horde_History": "^2.1",
         "pear-pear.horde.org/Horde_Icalendar": "^2",
         "pear-pear.horde.org/Horde_Image": "^2",
+        "pear-pear.horde.org/Horde_Itip": "^2",
         "pear-pear.horde.org/Horde_Lock": "^2",
         "pear-pear.horde.org/Horde_LoginTasks": "^2",
         "pear-pear.horde.org/Horde_Mail": "^2",


### PR DESCRIPTION
 as kronolith is lacking save codepaths in when Itip library is missing. It just assumes it is there and I feel it should be there.
Maybe it should be covered by another mandatory library already but in my install, it wasn't.
