### PR TITLE
Clarify the log message when there's an error parsing an event's timezone

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -698,7 +698,7 @@ abstract class Kronolith_Event
                     }
                     $params['TZID'] = $this->timezone;
                 } catch (Horde_Exception $e) {
-                    Horde::log('Unable to locate the tz database.', 'WARN');
+                    Horde::log('Unable to parse timezone for event ID ' . $this->_id . ': ' . $e, 'WARN');
                 }
             }
 


### PR DESCRIPTION
Using the WebDAV API, I imported some events that had timezones that Kronolith wasn't able to parse.  But Kronolith logged this misleading message:
```
WARN: HORDE [kronolith] Unable to locate the tz database.  [pid 35532 on line 732 of "/usr/share/horde/kronolith/lib/Event.php"]
```

The problem seems to be that it's catching all exceptions and assuming the problem is with the TZ database, when in fact the TZ database is present, but this event's particular timezone doesn't exist in the TZ database.  This PR adjusts the log message, to avoid logging an inaccurate assumption, and makes it easier to find and correct the offending events in the database.

After:
```
WARN: HORDE [kronolith] Unable to parse timezone for event ID Ew8KiNAXjfiKh_pS-ER2bu7: Horde_Timezone_Exception: Timezone GMT-0400 not found in /usr/share/pear/Horde/Timezone.php:139
Stack trace:
#0 /usr/share/horde/kronolith/lib/Event.php(725): Horde_Timezone->getZone('GMT-0400')
#1 /usr/share/horde/kronolith/lib/Application.php(800): Kronolith_Event->toiCalendar(Object(Horde_Icalendar))
#2 /usr/share/pear/Horde/Registry.php(1197): Kronolith_Application->davGetObject('calendar~...', 'Ew8KiNAXjfiKh_p...')
#3 /usr/share/pear/Horde/Dav/Calendar/Backend.php(159): Horde_Registry->callAppMethod('kronolith', 'davGetObject', Array)
#4 /usr/share/pear/Sabre/CalDAV/Calendar.php(110): Horde_Dav_Calendar_Backend->getCalendarObject('calendar~...', 'Ew8KiNAXjfiKh_p...')
#5 /usr/share/pear/Sabre/DAV/ObjectTree.php(72): Sabre\CalDAV\Calendar->getChild('Ew8KiNAXjfiKh_p...')
#6 /usr/share/pear/Sabre/DAV/Server.php(1473): Sabre\DAV\ObjectTree->getNodeForPath('calendars/...')
#7 /usr/share/pear/Sabre/CalDAV/Plugin.php(492): Sabre\DAV\Server->getPropertiesForPath('calendars/...', Array)
#8 /usr/share/pear/Sabre/CalDAV/Plugin.php(262): Sabre\CalDAV\Plugin->calendarMultiGetReport(Object(DOMDocument))
#9 [internal function]: Sabre\CalDAV\Plugin->report('{urn:ietf:param...', Object(DOMDocument), 'calendars/...')
#10 /usr/share/pear/Sabre/DAV/Server.php(433): call_user_func_array(Array, Array)
#11 /usr/share/pear/Sabre/DAV/Server.php(1066): Sabre\DAV\Server->broadcastEvent('report', Array)
#12 [internal function]: Sabre\DAV\Server->httpReport('calendars/...')
#13 /usr/share/pear/Sabre/DAV/Server.php(474): call_user_func(Array, 'calendars/...')
#14 /usr/share/pear/Sabre/DAV/Server.php(214): Sabre\DAV\Server->invokeMethod('REPORT', 'calendars/...')
#15 /usr/share/pear/Horde/Rpc/Webdav.php(66): Sabre\DAV\Server->exec()
#16 /usr/share/horde/rpc.php(160): Horde_Rpc_Webdav->getResponse('')
#17 /usr/share/horde/rpc/index.php(14): require('/usr/share/hord...')
#18 {main} [pid 53404 on line 729 of "/usr/share/horde/kronolith/lib/Event.php"]
```
