### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/docs/CHANGES
+++ b/docs/CHANGES
@@ -2,8 +2,7 @@
 v4.2.30
 -------
 
-
-
+[jan] Remove dependency on PEAR's Date package.
 
 -------
 v4.2.29

--- a/lib/Block/Monthlist.php
+++ b/lib/Block/Monthlist.php
@@ -113,9 +113,7 @@ class Kronolith_Block_Monthlist extends Horde_Core_Block
         }
 
         /* How many days do we need to check. */
-        $days = Date_Calc::dateDiff(
-            $startDate->mday, $startDate->month, $startDate->year,
-            $endDate->mday, $endDate->month, $endDate->year);
+        $days = $startDate->diff($endDate);
 
         /* Loop through the days. */
         $totalevents = 0;

--- a/lib/Block/Prevmonthlist.php
+++ b/lib/Block/Prevmonthlist.php
@@ -107,10 +107,7 @@ class Kronolith_Block_Prevmonthlist extends Horde_Core_Block
         $html = '';
 
         /* How many days do we need to check. */
-        $days = Date_Calc::dateDiff(
-            $startDate->mday, $startDate->month, $startDate->year,
-            $endDate->mday, $endDate->month, $endDate->year
-        );
+        $days = $startDate->diff($endDate);
 
         /* Loop through the days. */
         for ($i = 0; $i <= $days; ++$i) {

--- a/lib/Day.php
+++ b/lib/Day.php
@@ -111,9 +111,8 @@ class Kronolith_Day extends Horde_Date
 
     public function diff($other = null)
     {
-        $day2 = new Kronolith_Day();
-        return Date_Calc::dateDiff($this->mday, $this->month, $this->year,
-                                   $day2->mday, $day2->month, $day2->year);
+        $other = new Kronolith_Day();
+        return abs($this->toDays() - $other->toDays());
     }
 
 }

--- a/lib/Driver/Sql.php
+++ b/lib/Driver/Sql.php
@@ -105,17 +105,7 @@ class Kronolith_Driver_Sql extends Kronolith_Driver
                         }
                         $start = new Horde_Date($next);
                         $start->min -= $event->alarm;
-                        $diff = Date_Calc::dateDiff(
-                            $event->start->mday,
-                            $event->start->month,
-                            $event->start->year,
-                            $event->end->mday,
-                            $event->end->month,
-                            $event->end->year
-                        );
-                        if ($diff == -1) {
-                            $diff = 0;
-                        }
+                        $diff = $event->start->diff($event->end);
                         $end = new Horde_Date(array(
                             'year' => $next->year,
                             'month' => $next->month,

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -2171,17 +2171,7 @@ abstract class Kronolith_Event
                 return;
             }
             $start = clone $eventDate;
-            $diff = Date_Calc::dateDiff(
-                $this->start->mday,
-                $this->start->month,
-                $this->start->year,
-                $this->end->mday,
-                $this->end->month,
-                $this->end->year
-            );
-            if ($diff == -1) {
-                $diff = 0;
-            }
+            $diff = $this->start->diff($this->end);
             $end = new Horde_Date(array(
                 'year' => $start->year,
                 'month' => $start->month,
@@ -2484,12 +2474,7 @@ abstract class Kronolith_Event
         }
 
         if ($this->start && $this->end) {
-            $dur_day_match = Date_Calc::dateDiff($this->start->mday,
-                                                 $this->start->month,
-                                                 $this->start->year,
-                                                 $this->end->mday,
-                                                 $this->end->month,
-                                                 $this->end->year);
+            $dur_day_match = $this->start->diff($this->end);
             $dur_hour_match = $this->end->hour - $this->start->hour;
             $dur_min_match = $this->end->min - $this->start->min;
             while ($dur_min_match < 0) {

--- a/lib/FreeBusy/View/Month.php
+++ b/lib/FreeBusy/View/Month.php
@@ -49,7 +49,7 @@ class Kronolith_FreeBusy_View_Month extends Kronolith_FreeBusy_View
         $hours_html = '';
         $dayWidth = round(100 / $this->_days);
 
-        $week = Date_Calc::weekOfYear(1, $this->_start->month, $this->_start->year);
+        $week = $this->_start->weekOfYear();
         $span = (7 - $week) % 7 + 1;
         $span_left = $this->_days;
         $t = new Horde_Date($this->_start);

--- a/lib/FreeBusy/View/Week.php
+++ b/lib/FreeBusy/View/Week.php
@@ -90,7 +90,8 @@ class Kronolith_FreeBusy_View_Week extends Kronolith_FreeBusy_View
 
     protected function _render(Horde_Date $day = null)
     {
-        $this->_start = new Horde_Date(Date_Calc::beginOfWeek($day->mday, $day->month, $day->year, '%Y%m%d000000'));
+        $this->_start = clone $day;
+        $this->_start->mday -= ($this->_start->format('w') + 6) % 7;
         $this->_end = new Horde_Date($this->_start);
         $this->_end->hour = 23;
         $this->_end->min = $this->_end->sec = 59;

--- a/lib/Test.php
+++ b/lib/Test.php
@@ -32,11 +32,6 @@ class Kronolith_Test extends Horde_Test
      * @var array
      */
     protected $_pearList = array(
-        'Date' => array(
-            'path' => 'Date/Calc.php',
-            'error' => 'Kronolith requires the Date_Calc class to calculate dates.',
-            'required' => true,
-        ),
         'Date_Holidays' => array(
             'error' => 'Date_Holidays can be used to calculate and display national and/or religious holidays.',
             'required' => false,

--- a/lib/View/Month.php
+++ b/lib/View/Month.php
@@ -37,11 +37,6 @@ class Kronolith_View_Month
     /**
      * @var integer
      */
-    protected $_daysInView;
-
-    /**
-     * @var integer
-     */
     protected $_startOfView;
 
     /**
@@ -67,22 +62,8 @@ class Kronolith_View_Month
         $this->date = new Horde_Date($date);
         $this->date->mday = 1;
         $this->_startday = $this->date->dayOfWeek();
-        $this->_daysInView = Date_Calc::weeksInMonth($this->month, $this->year) * 7;
         if (!$prefs->getValue('week_start_monday')) {
             $this->_startOfView = 1 - $this->_startday;
-
-            // We may need to adjust the number of days in the view if
-            // we're starting weeks on Sunday.
-            if ($this->_startday == Horde_Date::DATE_SUNDAY) {
-                $this->_daysInView -= 7;
-            }
-            $endday = new Horde_Date(array('mday' => Horde_Date_Utils::daysInMonth($this->month, $this->year),
-                                           'month' => $this->month,
-                                           'year' => $this->year));
-            $endday = $endday->dayOfWeek();
-            if ($endday == Horde_Date::DATE_SUNDAY) {
-                $this->_daysInView += 7;
-            }
         } else {
             if ($this->_startday == Horde_Date::DATE_SUNDAY) {
                 $this->_startOfView = -5;
@@ -91,12 +72,17 @@ class Kronolith_View_Month
             }
         }
 
-        $startDate = new Horde_Date(array('year' => $this->year,
-                                          'month' => $this->month,
-                                          'mday' => $this->_startOfView));
-        $endDate = new Horde_Date(array('year' => $this->year,
-                                        'month' => $this->month,
-                                        'mday' => $this->_startOfView + $this->_daysInView));
+        $startDate = new Horde_Date(
+            $this->year, $this->month, $this->_startOfView
+        );
+        $endDate = new Horde_Date(
+            $this->year,
+            $this->month,
+            Horde_Date_Utils::daysInMonth($this->month, $this->year) + 1
+        );
+        $endDate->mday +=
+            (7 - ($endDate->format('w') - $prefs->getValue('week_start_monday')))
+            % 7;
 
         if ($prefs->getValue('show_shared_side_by_side')) {
             $allCalendars = Kronolith::listInternalCalendars();
@@ -147,6 +133,7 @@ class Kronolith_View_Month
         $new_url = Horde::url('new.php')->add('url', Horde::signUrl($this_link));
         $new_img = Horde::img('new_small.png', '+');
         $weekOffset = $prefs->getValue('week_start_monday') ? 0 : 1;
+        $weekStart = $prefs->getValue('week_start_monday');
 
         foreach ($this->_currentCalendars as $id => $cal) {
             if ($sidebyside) {
@@ -154,10 +141,13 @@ class Kronolith_View_Month
             }
 
             $cell = 0;
-            for ($day = $this->_startOfView; $day < $this->_startOfView + $this->_daysInView; ++$day) {
-                $date = new Kronolith_Day($this->month, $day, $this->year);
-                $date->hour = $twentyFour ? 12 : 6;
-
+            $date = new Kronolith_Day($this->month, $this->_startOfView, $this->year);
+            $date->hour = $twentyFour ? 12 : 6;
+            for (;
+                 $date->month <= $this->month ||
+                     ($date->month == 12 && $this->month == 1) ||
+                     $date->format('w') != $weekStart;
+                 $date->mday++) {
                 if ($cell % 7 == 0) {
                     $week = $date->add(array('day' => $weekOffset))->weekOfYear();
                     $weeklink = Horde::url('week.php')

--- a/lib/View/Year.php
+++ b/lib/View/Year.php
@@ -71,22 +71,12 @@ class Kronolith_View_Year
                                              'year' => $this->year));
             $startday = $startday->dayOfWeek();
 
-            $daysInView = Date_Calc::weeksInMonth($month, $this->year) * 7;
             if (!$prefs->getValue('week_start_monday')) {
                 $startOfView = 1 - $startday;
-
-                // We may need to adjust the number of days in the
-                // view if we're starting weeks on Sunday.
-                if ($startday == Horde_Date::DATE_SUNDAY) {
-                    $daysInView -= 7;
-                }
                 $endday = new Horde_Date(array('mday' => Horde_Date_Utils::daysInMonth($month, $this->year),
                                                'month' => $month,
                                                'year' => $this->year));
                 $endday = $endday->dayOfWeek();
-                if ($endday == Horde_Date::DATE_SUNDAY) {
-                    $daysInView += 7;
-                }
             } else {
                 if ($startday == Horde_Date::DATE_SUNDAY) {
                     $startOfView = -5;
@@ -98,7 +88,7 @@ class Kronolith_View_Year
             $currentCalendars = array(true);
             foreach ($currentCalendars as $id => $cal) {
                 $cell = 0;
-                for ($day = $startOfView; $day < $startOfView + $daysInView; ++$day) {
+                for ($day = $startOfView; $day < $startOfView + 42; ++$day) {
                     $date = new Kronolith_Day($month, $day, $this->year);
                     $date->hour = $prefs->getValue('twentyFour') ? 12 : 6;
                     $week = $date->weekOfYear();

--- a/package.xml
+++ b/package.xml
@@ -33,7 +33,6 @@
  </stability>
  <license uri="http://www.horde.org/licenses/gpl">GPL-2.0</license>
  <notes>
-* 
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -1021,10 +1020,6 @@
     <min>2.0.0</min>
     <max>3.0.0alpha1</max>
     <exclude>3.0.0alpha1</exclude>
-   </package>
-   <package>
-    <name>Date</name>
-    <channel>pear.php.net</channel>
    </package>
    <extension>
     <name>gettext</name>
@@ -4227,6 +4222,7 @@
    <date>2016-12-16</date>
    <license uri="http://www.horde.org/licenses/gpl">GPL-2.0</license>
    <notes>
+<<<<<<< HEAD
 * [mjr] Fix allowing ics import on when user has edit permissions on a shared calendar (Bug #14501).
 * [jan] Disallow setting of creator permissions too if sharing with world is disabled.
 * [jan] Split shared users by linebreaks too.
@@ -4406,7 +4402,7 @@
    <date>2020-07-12</date>
    <license uri="http://www.horde.org/licenses/gpl">GPL-2.0</license>
    <notes>
-* 
+* ([jan] Remove dependency on PEAR's Date package.) 
    </notes>
   </release>
   <release>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Kronolith/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Kronolith/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Kronolith Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Kronolith/Integration/AllDayTest.php
+++ b/test/Kronolith/Integration/AllDayTest.php
@@ -29,7 +29,7 @@
  */
 class Kronolith_Integration_AllDayTest extends Kronolith_TestCase
 {
-    static public function setupBeforeClass()
+    static public function setupBeforeClass(): void
     {
         $GLOBALS['calendar_manager'] = new Kronolith_Stub_CalendarManager();
     }

--- a/test/Kronolith/Integration/Driver/Base.php
+++ b/test/Kronolith/Integration/Driver/Base.php
@@ -53,14 +53,14 @@ class Kronolith_Integration_Driver_Base extends Kronolith_TestCase
      */
     private $_added = array();
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$setup = new Horde_Test_Setup();
         self::createBasicKronolithSetup(self::$setup);
         parent::setUpBeforeClass();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$driver = null;
         parent::tearDownAfterClass();
@@ -70,7 +70,7 @@ class Kronolith_Integration_Driver_Base extends Kronolith_TestCase
         unset($GLOBALS['session']);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $error = self::$setup->getError();
         if (!empty($error)) {
@@ -78,7 +78,7 @@ class Kronolith_Integration_Driver_Base extends Kronolith_TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         foreach ($this->_added as $added) {

--- a/test/Kronolith/Integration/Driver/KolabTest.php
+++ b/test/Kronolith/Integration/Driver/KolabTest.php
@@ -31,7 +31,7 @@ class Kronolith_Integration_Driver_KolabTest extends Kronolith_Integration_Drive
 {
     protected $backupGlobals = false;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         return;
         parent::setUpBeforeClass();
@@ -41,7 +41,7 @@ class Kronolith_Integration_Driver_KolabTest extends Kronolith_Integration_Drive
         self::$type = 'Kolab';
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Unserialization error from Kolab share objects.');
     }

--- a/test/Kronolith/Integration/Driver/Sql/Base.php
+++ b/test/Kronolith/Integration/Driver/Sql/Base.php
@@ -31,7 +31,7 @@ class Kronolith_Integration_Driver_Sql_Base extends Kronolith_Integration_Driver
 {
     static $callback;
 
-    static public function setUpBeforeClass()
+    static public function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::getDb();

--- a/test/Kronolith/Integration/Driver/Sql/Pdo/SqliteTest.php
+++ b/test/Kronolith/Integration/Driver/Sql/Pdo/SqliteTest.php
@@ -31,7 +31,7 @@ class Kronolith_Integration_Driver_Sql_Pdo_SqliteTest extends Kronolith_Integrat
 {
     protected $backupGlobals = false;
 
-    static public function setUpBeforeClass()
+    static public function setUpBeforeClass(): void
     {
         self::$callback = array(__CLASS__, 'getDb');
         parent::setUpBeforeClass();

--- a/test/Kronolith/Integration/FromIcalendarTest.php
+++ b/test/Kronolith/Integration/FromIcalendarTest.php
@@ -29,13 +29,13 @@
  */
 class Kronolith_Integration_FromIcalendarTest extends Kronolith_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->_timezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Berlin');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->_timezone);
     }
@@ -107,6 +107,8 @@ class Kronolith_Integration_FromIcalendarTest extends Kronolith_TestCase
 
     public function testInvalidTimezone()
     {
+        $this->expectNotToPerformAssertions();
+
         $GLOBALS['conf']['calendar']['driver'] = 'Mock';
         $GLOBALS['injector'] = new Horde_Injector(new Horde_Injector_TopLevel());
         $event = $this->_getFixture('bug11688.ics', 1);

--- a/test/Kronolith/Integration/Kronolith/Base.php
+++ b/test/Kronolith/Integration/Kronolith/Base.php
@@ -43,14 +43,14 @@ class Kronolith_Integration_Kronolith_Base extends Kronolith_TestCase
      */
     protected $default_name = 'Calendar of test@example.com';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$setup = new Horde_Test_Setup();
         self::createBasicKronolithSetup(self::$setup);
         parent::setUpBeforeClass();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
         unset($GLOBALS['registry']);
@@ -59,7 +59,7 @@ class Kronolith_Integration_Kronolith_Base extends Kronolith_TestCase
         unset($GLOBALS['session']);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $GLOBALS['conf']['autoshare']['shareperms'] = 'none';
         $error = self::$setup->getError();
@@ -68,7 +68,7 @@ class Kronolith_Integration_Kronolith_Base extends Kronolith_TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         foreach ($GLOBALS['injector']->getInstance('Kronolith_Shares')->listShares('test@example.com') as $share) {
             $GLOBALS['injector']->getInstance('Kronolith_Shares')->removeShare($share);

--- a/test/Kronolith/Integration/Kronolith/KolabTest.php
+++ b/test/Kronolith/Integration/Kronolith/KolabTest.php
@@ -38,7 +38,7 @@ class Kronolith_Integration_Kronolith_KolabTest extends Kronolith_Integration_Kr
      */
     protected $default_name = 'Calendar';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         return;
         self::$setup = new Horde_Test_Setup();
@@ -46,7 +46,7 @@ class Kronolith_Integration_Kronolith_KolabTest extends Kronolith_Integration_Kr
         self::createKolabShares(self::$setup);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete("No query of type 'Share' registered!");
     }

--- a/test/Kronolith/Integration/Kronolith/Sql/Base.php
+++ b/test/Kronolith/Integration/Kronolith/Sql/Base.php
@@ -31,7 +31,7 @@ class Kronolith_Integration_Kronolith_Sql_Base extends Kronolith_Integration_Kro
 {
     static $callback;
 
-    static public function setUpBeforeClass()
+    static public function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::getDb();

--- a/test/Kronolith/Integration/Kronolith/Sql/Pdo/SqliteTest.php
+++ b/test/Kronolith/Integration/Kronolith/Sql/Pdo/SqliteTest.php
@@ -31,7 +31,7 @@ class Kronolith_Integration_Kronolith_Sql_Pdo_SqliteTest extends Kronolith_Integ
 {
     protected $backupGlobals = false;
 
-    static public function setUpBeforeClass()
+    static public function setUpBeforeClass(): void
     {
         self::$callback = array(__CLASS__, 'getDb');
         parent::setUpBeforeClass();

--- a/test/Kronolith/Integration/ToIcalendarTest.php
+++ b/test/Kronolith/Integration/ToIcalendarTest.php
@@ -29,7 +29,7 @@
  */
 class Kronolith_Integration_ToIcalendarTest extends Kronolith_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->_timezone = date_default_timezone_get();
         date_default_timezone_set('Europe/Berlin');
@@ -43,7 +43,7 @@ class Kronolith_Integration_ToIcalendarTest extends Kronolith_TestCase
         $GLOBALS['conf']['calendar']['driver'] = 'Mock';
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($GLOBALS['registry']);
         unset($GLOBALS['injector']);

--- a/test/Kronolith/TestCase.php
+++ b/test/Kronolith/TestCase.php
@@ -47,7 +47,8 @@ extends Horde_Test_Case
             array(
                 '_PARAMS' => array(
                     'user' => 'test@example.com',
-                    'app' => 'kronolith'
+                    'app' => 'kronolith',
+                    'noset' => true,
                 ),
                 'Horde_Alarm' => 'Alarm',
                 'Horde_Cache' => 'Cache',

--- a/test/Kronolith/TestCase.php
+++ b/test/Kronolith/TestCase.php
@@ -28,7 +28,7 @@
  * @license    http://www.horde.org/licenses/gpl GNU General Public License, version 2
  */
 class Kronolith_TestCase
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     protected function getInjector()
     {

--- a/test/Kronolith/phpunit.xml
+++ b/test/Kronolith/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-kronolith/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian change: Set 'noset' parameter for SessionHandler instance creation during unit tests. https://salsa.debian.org/horde-team/php-horde-kronolith/-/blob/debian-sid/debian/patches/1001_set-noset-parameter-for-session-handler-instance.patch
