### PR TITLE
Attendee.php: Fix issue with wrong data supplied to __unserialize()

### DIFF
--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -21,6 +21,7 @@
  * @property-read string $displayName A simple label to identify the attendee.
  * @property-read string $id An ID for this attendee.
  */
+// TODO: Serializable interface is deprecated
 class Kronolith_Attendee implements Serializable
 {
     /**
@@ -230,10 +231,13 @@ class Kronolith_Attendee implements Serializable
 
     /**
      */
+
+    // TODO: Remove serialize() - Serializable interface is deprecated
     public function serialize()
     {
         return array_shift($this->__serialize());
     }
+
     public function __serialize(): array
     {
         return [
@@ -247,11 +251,13 @@ class Kronolith_Attendee implements Serializable
 
     /**
      */
-    public function unserialize($data)
+    // TODO: Remove unserialize() - Serializable interface is deprecated
+    public function unserialize(string $data)
     {
-        $this->__unserialize([$data]);
-
+        $data = unserialize($data);
+        $this->__unserialize($data);
     }
+
     public function __unserialize(array $data): void
     {
         $this->user     = $data['u'];


### PR DESCRIPTION
This fixes an issue which manifests itself as warnings like the below by properly unserializing string supplied in`$data` parameter.

```
[kronolith] PHP ERROR: Undefined array key "u"  [pid XXXXX on line 260 of ".../vendor/horde/kronolith/lib/Attendee.php"]
[kronolith] PHP ERROR: Undefined array key "e"  [pid XXXXX on line 261 of ".../vendor/horde/kronolith/lib/Attendee.php"]
[kronolith] PHP ERROR: Undefined array key "p"  [pid XXXXX on line 262 of ".../vendor/horde/kronolith/lib/Attendee.php"]
[kronolith] PHP ERROR: Undefined array key "r"  [pid XXXXX on line 263 of ".../vendor/horde/kronolith/lib/Attendee.php"]
[kronolith] PHP ERROR: Undefined array key "n"  [pid XXXXX on line 264 of ".../vendor/horde/kronolith/lib/Attendee.php"]
```
@ralflang: We could also drop the unserialize()/serialize() altogether, as Serializable interface is [deprecated](https://php.watch/versions/8.1/serializable-deprecated) since PHP 8.1.