### PR TITLE
meta: update translator list and correct email address

### DIFF
--- a/locale/fr/LC_MESSAGES/kronolith.po
+++ b/locale/fr/LC_MESSAGES/kronolith.po
@@ -8,7 +8,7 @@
 # Laurent Foucher <laurent.foucher@iut-tlse3.fr>, 2011.
 # Yannick SEBASTIA <yannick.sebastia@ecole-navale.fr>, 2011.
 # Paul De Vlieger <paul.de_vlieger@moniut.univ-bpclermont.fr>, 2013
-# Jean Charles Delépine <deleoine@u-picardie.fr>, 2025
+# Jean Charles Delépine <delepine@u-picardie.fr>, 2025
 # Kronolith 2.2-cvs French translation
 # Copyright 2001 Mikhaël Janson.
 # Copyright 2002, 2003, 2005, 2006, 2007 Thierry Thomas.

--- a/locale/fr/LC_MESSAGES/kronolith.po
+++ b/locale/fr/LC_MESSAGES/kronolith.po
@@ -8,6 +8,7 @@
 # Laurent Foucher <laurent.foucher@iut-tlse3.fr>, 2011.
 # Yannick SEBASTIA <yannick.sebastia@ecole-navale.fr>, 2011.
 # Paul De Vlieger <paul.de_vlieger@moniut.univ-bpclermont.fr>, 2013
+# Jean Charles Delépine <deleoine@u-picardie.fr>, 2025
 # Kronolith 2.2-cvs French translation
 # Copyright 2001 Mikhaël Janson.
 # Copyright 2002, 2003, 2005, 2006, 2007 Thierry Thomas.
@@ -18,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: dev@lists.horde.org\n"
 "POT-Creation-Date: 2025-07-12 20:14+0200\n"
 "PO-Revision-Date: 2025-07-13 15:37+0200\n"
-"Last-Translator: Jean Charles Delépine <deleoine@u-picardie.fr>\n"
+"Last-Translator: Jean Charles Delépine <delepine@u-picardie.fr>\n"
 "Language-Team: French <kde-i18n-doc@kde.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"


### PR DESCRIPTION
This PR updates only the PO metadata:
– Adds myself to the translator list
– Fixes my email address
No translation strings are modified.