### PR TITLE
Correct config name for caldav events backend

### DIFF
--- a/lib/Factory/IcalendarStorage.php
+++ b/lib/Factory/IcalendarStorage.php
@@ -23,7 +23,7 @@ class Kronolith_Factory_IcalendarStorage
      */
     public function create(Horde_Injector $injector): Kronolith_Icalendar_Storage
     {
-        $driver = Horde_String::ucfirst($GLOBALS['conf']['icalendar']['driver']);
+        $driver = Horde_String::ucfirst($GLOBALS['conf']['caldav']['driver']);
 
         if (!empty($this->_instances[$driver])) {
             return $this->_instances[$driver];
@@ -31,7 +31,7 @@ class Kronolith_Factory_IcalendarStorage
 
         switch ($driver) {
             case 'Sql':
-                $params = Horde::getDriverConfig('icalendar', 'Sql');
+                $params = Horde::getDriverConfig('caldav', 'Sql');
                 if (isset($params['driverconfig']) &&
                     $params['driverconfig'] != 'horde') {
                     $customParams = $params;


### PR DESCRIPTION
Commit 3d58542 introduced an optional backend to store incoming CalDAV events.

It added a `caldav` config section, however the code in `lib/Factory/IcalendarStorage.php` refers to `icalendar`:
```php
$driver = Horde_String::ucfirst($GLOBALS['conf']['icalendar']['driver']);
...
$params = Horde::getDriverConfig('icalendar', 'Sql');
```
This makes it impossible to specify a custom backend.

This also results in annoying error messages in the log when CalDAV is used:
`[kronolith] PHP ERROR: Undefined array key "icalendar"`
`[kronolith] PHP ERROR: Trying to access array offset on value of type null`
