### PR TITLE
Ical.php fixes

### DIFF
--- a/lib/Driver/Ical.php
+++ b/lib/Driver/Ical.php
@@ -39,13 +39,6 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
     protected $_cache = [];
 
     /**
-     * DAV client object.
-     *
-     * @var \Sabre\DAV\Client
-     */
-    protected $_client;
-
-    /**
      * A list of DAV support levels.
      *
      * @var array
@@ -67,7 +60,6 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
     public function open($calendar)
     {
         parent::open($calendar);
-        $this->_client = null;
         $this->_permission = 0;
         unset($this->_davSupport);
     }
@@ -1020,24 +1012,24 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
             $options['password'] = $this->_params['password'];
         }
 
-        $this->_client = new Client($options);
+        $client = new Client($options);
 
-        $this->_client->addCurlSetting(
+        $client->addCurlSetting(
             CURLOPT_TIMEOUT,
             $this->_params['timeout'] ?? 5
         );
         if (!empty($conf['http']['proxy']['proxy_host'])) {
-            $this->_client->addCurlSetting(
+            $client->addCurlSetting(
                 CURLOPT_PROXY,
                 $conf['http']['proxy']['proxy_host']
             );
-            $this->_client->addCurlSetting(
+            $client->addCurlSetting(
                 CURLOPT_PROXYPORT,
                 $conf['http']['proxy']['proxy_port']
             );
             if (!empty($conf['http']['proxy']['proxy_user']) &&
                 !empty($conf['http']['proxy']['proxy_pass'])) {
-                $this->_client->addCurlSetting(
+                $client->addCurlSetting(
                     CURLOPT_PROXYUSERPWD,
                     $conf['http']['proxy']['proxy_user'] . ':' .
                     $conf['http']['proxy']['proxy_pass']
@@ -1045,7 +1037,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
             }
         }
 
-        return $this->_client;
+        return $client;
     }
 
 }

--- a/lib/Driver/Ical.php
+++ b/lib/Driver/Ical.php
@@ -157,7 +157,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
      *                                   toJson() method?
      * @param boolean $coverDates        Whether to add the events to all days
      *                                   that they cover.
-     * $param boolean $hideExceptions    Hide events that represent exceptions
+     * @param boolean $hideExceptions    Hide events that represent exceptions
      *                                   to a recurring event.
      *
      * @return array  Events in the given time range.
@@ -177,7 +177,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
         if (is_null($startDate)) {
             $startDate = new Horde_Date(['mday' => 1,
                 'month' => 1,
-                'year' => 0o000]);
+                'year' => 0000]);
         }
         if (is_null($endDate)) {
             $endDate = new Horde_Date(['mday' => 31,
@@ -221,7 +221,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
      *                                   toJson() method?
      * @param boolean $coverDates        Whether to add the events to all days
      *                                   that they cover.
-     * $param boolean $hideExceptions    Hide events that represent exceptions
+     * @param boolean $hideExceptions    Hide events that represent exceptions
      *                                   to a recurring event.
      *
      * @return array  Events in the given time range.
@@ -471,7 +471,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
                 $eventId = $matches[1];
                 //$recurrenceId = $matches[2];
             }
-            $url = trim($this->_getUrl(), '/') . '/' . $eventId;
+            $url = $this->_getUrl($eventId);
             try {
                 $response = $this->_getClient($url)->request('GET');
             } catch (\Sabre\HTTP\ClientException $e) {
@@ -596,7 +596,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
         $ical = new Horde_Icalendar();
         $ical->addComponent($event->toiCalendar($ical));
 
-        $url = trim($this->_getUrl(), '/') . '/' . $event->id;
+        $url = $this->_getUrl($event->id);
         try {
             return $this->_getClient($url)
                 ->request(
@@ -643,7 +643,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
             throw new Kronolith_Exception(_("Cannot delete exceptions (yet)."));
         }
 
-        $url = trim($this->_getUrl(), '/') . '/' . $eventId;
+        $url = $this->_getUrl($eventId);
         try {
             $response = $this->_getClient($url)->request('DELETE');
         } catch (\Sabre\HTTP\ClientException $e) {
@@ -772,7 +772,7 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
 
     /**
      * Returns whether the remote calendar is a CalDAV server, and propagates
-     * the $_davSupport propery with the server's DAV capabilities.
+     * the $_davSupport property with the server's DAV capabilities.
      *
      * @return boolean  True if the remote calendar is a CalDAV server.
      * @throws Kronolith_Exception
@@ -978,9 +978,11 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
      * Does any necessary trimming and URL scheme fixes on the user-provided
      * calendar URL.
      *
+     * @param string|null $eventId  Optional event ID.
+     *
      * @return string  The URL of this calendar.
      */
-    protected function _getUrl()
+    protected function _getUrl(?string $eventId = null)
     {
         $url = trim($this->calendar);
         if (strpos($url, 'http') !== 0) {
@@ -990,6 +992,13 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
                 $url
             );
         }
+
+        if (!is_null($eventId)) {
+            $hurl = new Horde_Url($url, true);
+            $hurl->pathInfo = $eventId;
+            $url = (string) $hurl;
+        }
+
         return $url;
     }
 

--- a/lib/Driver/Ical.php
+++ b/lib/Driver/Ical.php
@@ -506,7 +506,9 @@ class Kronolith_Driver_Ical extends Kronolith_Driver
                     false,
                     $eventId
                 );
-                $event = reset(reset($results));
+
+                $first = reset($results);
+                $event = $first ? reset($first) : false;
                 if (!$event) {
                     throw new Horde_Exception_NotFound(_("Event not found"));
                 }


### PR DESCRIPTION
This allows to use CalDAV calendars whose URLs contain query strings (e.g. Nextcloud does it) or fragments, where the previous trim/concatenation would produce malformed event URLs.

* Add safeguard against reset() called on empty results
* Remove unneeded $_client property in Kronolith_Driver_Ical class
* Refactor _getUrl() to accept an optional event ID, using Horde_Url for proper path handling 
* Also fix typos in docblocks, and replace the PHP 8.1 octal literal 0o000 with 0000 for broader compatibility

