### PR TITLE
Add default case to event status handling

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -4460,6 +4460,9 @@ abstract class Kronolith_Event
             case Kronolith::STATUS_TENTATIVE:
             case Kronolith::STATUS_FREE:
                 return 'kronolith-event-tentative';
+            
+            default:
+                return '';
         }
     }
 


### PR DESCRIPTION
As Horde\Core\Horde::linkTooltip() now expects string, we need to add a empty string as default return in getStatusClass()