### PR TITLE
Fix/calender folder lifecycle

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -1764,14 +1764,10 @@ class Kronolith_Api extends Horde_Registry_Api
             $calendar = $GLOBALS['injector']
                 ->getInstance('Kronolith_Shares')
                 ->getShare($id);
-        } catch (Horde_Exception_NotFound $e) {
-            Kronolith::removeCalendarFromSyncCalendars($id);
-            Kronolith::removeCalendarFromDisplayCalendarsPref($id);
-            Kronolith::removeActiveSyncCalendarCollectionsFromDeviceCache($id);
-            Kronolith::notifyActiveSyncOfCalendarChange();
-            return;
-        } catch (Horde_Share_Exception $e) {
-            if (strpos($e->getMessage(), 'not found') === false) {
+        } catch (Horde_Exception_NotFound|Horde_Share_Exception $e) {
+            if ($e instanceof Horde_Share_Exception
+                && stripos($e->getMessage(), 'not found') === false
+            ) {
                 throw $e;
             }
             Kronolith::removeCalendarFromSyncCalendars($id);

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -1736,8 +1736,6 @@ class Kronolith_Api extends Horde_Registry_Api
      */
     public function addCalendar($name, array $params = [])
     {
-        global $prefs;
-
         $info = [
             'name' => $name,
             'color' => empty($params['color']) ? null : $params['color'],
@@ -1748,9 +1746,8 @@ class Kronolith_Api extends Horde_Registry_Api
         $share = Kronolith::addShare($info);
 
         if (!empty($params['synchronize'])) {
-            $sync = @unserialize($prefs->getValue('sync_calendars'));
-            $sync[] = $share->getName();
-            $prefs->setValue('sync_calendars', serialize($sync));
+            Kronolith::addCalendarToSyncCalendars($share->getName());
+            Kronolith::notifyActiveSyncOfCalendarChange();
         }
 
         return $share->getName();
@@ -1763,9 +1760,27 @@ class Kronolith_Api extends Horde_Registry_Api
      */
     public function deleteCalendar($id)
     {
-        $calendar = $GLOBALS['injector']
-            ->getInstance('Kronolith_Shares')
-            ->getShare($calendar);
+        try {
+            $calendar = $GLOBALS['injector']
+                ->getInstance('Kronolith_Shares')
+                ->getShare($id);
+        } catch (Horde_Exception_NotFound $e) {
+            Kronolith::removeCalendarFromSyncCalendars($id);
+            Kronolith::removeCalendarFromDisplayCalendarsPref($id);
+            Kronolith::removeActiveSyncCalendarCollectionsFromDeviceCache($id);
+            Kronolith::notifyActiveSyncOfCalendarChange();
+            return;
+        } catch (Horde_Share_Exception $e) {
+            if (strpos($e->getMessage(), 'not found') === false) {
+                throw $e;
+            }
+            Kronolith::removeCalendarFromSyncCalendars($id);
+            Kronolith::removeCalendarFromDisplayCalendarsPref($id);
+            Kronolith::removeActiveSyncCalendarCollectionsFromDeviceCache($id);
+            Kronolith::notifyActiveSyncOfCalendarChange();
+            return;
+        }
+
         Kronolith::deleteShare($calendar);
     }
 


### PR DESCRIPTION
# Stabilize Kronolith calendar folder lifecycle for ActiveSync

## Summary

- Fix deleting Kronolith calendars through ActiveSync `FolderDelete` by resolving the requested calendar id correctly.
- Clean deleted calendar ids from `sync_calendars` and `display_cals`.
- Add a lightweight FolderSync wakeup for calendar folder add/update/delete without wiping stored ActiveSync state.
- Refresh Kronolith web-session calendar state when calendar folders are changed by ActiveSync or another session.

## Problem

Kronolith calendar folders were mostly usable through ActiveSync 16.0, but folder lifecycle handling still had several issues:

- Deleting a calendar from iOS failed because `Kronolith_Api::deleteCalendar()` passed an undefined `$calendar` variable into `getShare()` instead of using the calendar id from the request.
- Deleted calendars could remain in `sync_calendars` and `display_cals`, leaving stale preference references behind.
- Calendar folder add/update/delete needed to wake client FolderSync, but clearing full ActiveSync state is too heavy and can cause synckey mismatch cascades.
- The open Kronolith web UI could keep preference/share-list state from its PHP session, while ActiveSync changed the calendar list in a separate request.

## Solution

### Calendar delete path

`Kronolith_Api::deleteCalendar()` now loads the share using the requested `$id` and calls `Kronolith::deleteShare()` only after the share has been resolved.

If a client repeats a delete for a calendar that is already gone, the method treats that as idempotent cleanup: it removes the calendar id from local display/sync preferences, drops stale ActiveSync collection cache entries for that calendar, wakes FolderSync, and returns without raising a fatal error.

### Preference cleanup

Kronolith now has helper methods for calendar preference lists:

- `addCalendarToDisplayCalendarsPref()`
- `removeCalendarFromDisplayCalendarsPref()`
- `addCalendarToSyncCalendars()`
- `removeCalendarFromSyncCalendars()`

Calendar deletion removes the share id from both `sync_calendars` and `display_cals`. Calendar creation through ActiveSync adds the created calendar to `sync_calendars` without duplicating entries.

`getSyncCalendars(true)` now returns the pruned list after removing no-longer-existing calendar ids, instead of persisting a cleaned preference but returning the stale in-memory list.

### FolderSync wakeup

Calendar add/update/delete now calls `Kronolith::notifyActiveSyncOfCalendarChange()`.

That method:

1. Marks Kronolith calendar list data as changed for other sessions.
2. Persists preference changes immediately.
3. Sets the hierarchy synckey in each affected device's sync cache to `0`.
4. Keeps folder mappings and stored FolderSync state intact so clients can receive normal FolderHierarchy Add/Update/Delete changes.

For web-side calendar deletion, Kronolith removes only the deleted calendar's collection/PING entries from the ActiveSync device cache. It intentionally keeps folder cache mappings so the next FolderSync can still deliver the folder deletion cleanly.

### Web-session cache refresh

Kronolith now has a hidden/implicit `calendar_cache_ts` preference used as a session-independent calendar-list change marker.

`Kronolith::refreshWebSessionState()` runs during app initialization. It reloads preferences, compares `calendar_cache_ts` to the value last seen by the current web session, and expires the `Kronolith_Shares` list cache only when needed.

This avoids expiring the share cache on every Kronolith request while still letting an already-open web session notice calendar folder changes made by ActiveSync or another session.

## Files changed

- `vendor/horde/kronolith/lib/Api.php`
- `vendor/horde/kronolith/lib/Kronolith.php`
- `vendor/horde/kronolith/config/prefs.php`

## Validation

- `php -l` completed successfully for the edited Kronolith PHP files.
- Cursor lints reported no errors for the edited Kronolith files.
- Manual iOS ActiveSync testing confirmed that calendar deletion now completes and removes the calendar from Kronolith without the previous backend failure.

## Test plan

- [ ] In Kronolith web UI, create a calendar and confirm it appears on iOS with ActiveSync 16.0 and `activesync_no_multiplex` enabled.
- [ ] Rename a calendar in the web UI and confirm iOS receives the folder update.
- [ ] Delete a calendar in the web UI and confirm iOS receives the folder removal without PING status 132 or synckey mismatch loops.
- [ ] Create a calendar on iOS and confirm it appears in Kronolith without requiring logout/login.
- [ ] Rename a calendar on iOS and confirm Kronolith reflects the change after a normal page refresh.
- [ ] Delete a calendar on iOS and confirm it is removed from Kronolith and from `sync_calendars` / `display_cals`.
- [ ] Check `/tmp-horde/horde.log` after iOS FolderDelete; confirm there is no Kronolith `deleteCalendar()` error.

## Known follow-ups

- If Kronolith is already open in the browser while iOS deletes the currently displayed calendar, the web UI can still show a transient red "access denied" toast until the UI state refreshes. This appears to be a stale selected-calendar/Ajax state issue in the open web page, not a backend ActiveSync failure.
- Recurring appointment import/edit from iOS remains outside this phase and should be handled separately.
- Calendar item `MoveItems` state handling remains outside this phase and still needs the non-mail mapping fix identified earlier.
