### PR TITLE
Fix recurrence rule update logic

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -1932,17 +1932,17 @@ abstract class Kronolith_Event
              * drawback to this is that the UIDs will change. */
             $kronolith_driver = $this->getDriver();
 
-            // EAS 16 doesn't update exception data on edits of the base event
-            // but still sends the recurrence rule. We need to replace the
-            // recurrence rule if it changed (and overwrite any exceptions),
-            // otherwise leave it alone.
-            if ($version >= Horde_ActiveSync::VERSION_SIXTEEN) {
-                if (!empty($this->uid)
-                    && !empty($this->recurrence)
-                    && !$this->recurrence->isEqual($rrule)) {
+            if (empty($this->recurrence) || !$this->recurrence->isEqual($rrule)) {
+                // EAS 16 doesn't update exception data on edits of the base
+                // event, but still sends the recurrence rule. If the rule
+                // changed, overwrite existing exceptions; otherwise only set
+                // the rule for new events or events becoming recurring.
+                if ($version >= Horde_ActiveSync::VERSION_SIXTEEN
+                    && !empty($this->uid)
+                    && !empty($this->recurrence)) {
                     $this->disconnectExceptions(true);
-                    $this->recurrence = $rrule;
                 }
+                $this->recurrence = $rrule;
             }
 
             if (!empty($this->uid)


### PR DESCRIPTION
# Import ActiveSync recurring appointments into Kronolith

## Summary

- Persist valid ActiveSync recurrence rules when importing Kronolith appointments.
- Fix new iOS-created recurring events being saved as normal single appointments.
- Fix iOS edits that turn a single appointment into a recurring appointment or change an existing recurrence rule.
- Preserve the existing EAS 16 exception behavior: bound exceptions are only disconnected when the base recurrence rule actually changes.

## Problem

ActiveSync 16.0 recurrence export from Kronolith to iOS already worked, but import from iOS was incomplete.

When `Kronolith_Event::fromASAppointment()` received a `Horde_ActiveSync_Message_Appointment`, it called `$message->getRecurrence()` and stored the result in `$rrule`. However, for EAS 16 the code only assigned `$rrule` to `$this->recurrence` if all of these were true:

- the event already had a UID,
- the event already had a recurrence object,
- and the incoming recurrence rule differed from the existing one.

That skipped the important cases:

- a new recurring appointment created on iOS,
- an existing non-recurring appointment changed into a recurring appointment,
- or any valid recurrence import where `$this->recurrence` was still empty.

The result was that iOS-created series appointments could appear in Kronolith as normal single appointments, and later series edits had no valid base recurrence to operate on.

## Solution

`Kronolith_Event::fromASAppointment()` now assigns a valid incoming ActiveSync recurrence rule whenever the event has no recurrence yet or the incoming rule differs from the current rule.

For EAS 16, existing bound exceptions are still only disconnected when all of these are true:

1. the event already exists,
2. it already has a recurrence object,
3. and the recurrence rule changed.

This keeps the existing EAS 16 exception model intact while making recurrence import work for newly-created and newly-recurring events.

## Files changed

- `vendor/horde/kronolith/lib/Event.php`

## Validation

- `php -l vendor/horde/kronolith/lib/Event.php` completed successfully.
- Cursor lints reported no errors for `vendor/horde/kronolith/lib/Event.php`.
- Manual iOS ActiveSync 16.0 testing confirmed the following flows now work:
  - Create weekly recurring appointment on iOS -> visible in Kronolith as a recurring appointment.
  - Create daily recurring appointment with an end date on iOS -> visible in Kronolith as a finite recurring appointment.
  - Edit iOS-created weekly series title and interval -> Kronolith reflects the updated title and recurrence.
  - Delete one occurrence from iOS -> Kronolith keeps the base series and skips the deleted occurrence.

## ActiveSync log evidence

The iOS test device sent complete recurrence payloads during the successful tests.

Weekly create:

- Subject: `EAS16 weekly test`
- Incoming `Add`
- Recurrence:
  - `Type = 1` (weekly)
  - `Interval = 1`
  - `DayOfWeek = 8`
  - `FirstDayOfWeek = 1`
- Server response status: `1`

Daily finite create:

- Subject: `EAS16 daily count test`
- Incoming `Add`
- Recurrence:
  - `Type = 0` (daily)
  - `Interval = 1`
  - `Until = 20260529T110000Z`
  - `FirstDayOfWeek = 1`
- Server response status: `1`

Weekly series edit:

- Subject: `EAS16 weekly test edited`
- Incoming `Modify`
- Recurrence:
  - `Type = 1` (weekly)
  - `Interval = 2`
  - `DayOfWeek = 8`
  - `FirstDayOfWeek = 1`
- Server response status: `1`

Single occurrence delete:

- Incoming `Remove`
- `AirSyncBase:InstanceId = 20260610T090000Z`
- Horde exported the series again with `Interval = 2` and an `Exceptions` block containing that instance id.
- Server response status: `1`

No new Horde errors were observed in `/tmp-horde/horde.log` during these tests.

## Test plan

- [ ] Create a weekly recurring appointment on iOS and confirm Kronolith shows it as a recurring event.
- [ ] Create a daily recurring appointment with an end date on iOS and confirm Kronolith shows the expected finite recurrence.
- [ ] Edit the iOS-created weekly series by changing title and recurrence interval; confirm Kronolith reflects both changes.
- [ ] Delete a single occurrence from the iOS-created weekly series and confirm Kronolith keeps the base series but skips that occurrence.
- [ ] Check the iOS ActiveSync log for non-empty `POOMCAL:Recurrence` blocks in `Add` and `Modify` commands.
- [ ] Check `/tmp-horde/horde.log` for warnings/errors during recurrence add/edit/delete tests.

## Known follow-ups

- This PR only fixes recurrence assignment during import. It does not change ActiveSync `MoveItems` handling for calendar items.
- More complex recurrence patterns, such as monthly nth weekday or yearly nth weekday created from iOS, should still be tested separately before declaring full recurrence coverage.
