### PR TITLE
Fix/UI handling of eas calender changes

### DIFF
--- a/config/prefs.php
+++ b/config/prefs.php
@@ -299,6 +299,9 @@ $_prefs['sync_calendars'] = [
     },
     'on_change' => function () {
         $sync = @unserialize($GLOBALS['prefs']->getValue('sync_calendars'));
+        if (!is_array($sync)) {
+            $sync = [];
+        }
         $haveDefault = false;
         $default = Kronolith::getDefaultCalendar(Horde_Perms::DELETE);
         foreach ($sync as $cid) {
@@ -313,17 +316,8 @@ $_prefs['sync_calendars'] = [
         }
         if ($GLOBALS['conf']['activesync']['enabled']) {
             try {
-                $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
-                $sm->setLogger($GLOBALS['injector']->getInstance('Horde_Log_Logger'));
-                $devices = $sm->listDevices($GLOBALS['registry']->getAuth());
-                foreach ($devices as $device) {
-                    $sm->removeState([
-                        'devId' => $device['device_id'],
-                        'id' => Horde_Core_ActiveSync_Driver::APPOINTMENTS_FOLDER_UID,
-                        'user' => $GLOBALS['registry']->getAuth(),
-                    ]);
-                }
-                $GLOBALS['notification']->push(_("All state removed for your ActiveSync devices. They will resynchronize next time they connect to the server."));
+                Kronolith::notifyActiveSyncOfCalendarChange();
+                $GLOBALS['notification']->push(_("Calendar synchronization settings saved. Your device will update calendar folders on the next sync."));
             } catch (Horde_ActiveSync_Exception $e) {
                 $GLOBALS['notification']->push(_("There was an error communicating with the ActiveSync server: %s"), $e->getMessage(), 'horde.error');
             }

--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -77,6 +77,11 @@ class Kronolith
     public const VFS_PATH = '.horde/kronolith/documents';
 
     /**
+     * Cache key prefix for cross-session calendar list invalidation markers.
+     */
+    public const CALENDAR_CACHE_TS_PREFIX = 'kronolith.calendar_cache_ts.';
+
+    /**
      * @var Kronolith_Tagger
      */
     private static $_tagger;
@@ -808,6 +813,7 @@ class Kronolith
      */
     public static function initialize()
     {
+        self::refreshWebSessionState();
         $GLOBALS['calendar_manager'] = $GLOBALS['injector']->createInstance('Kronolith_CalendarsManager');
     }
 
@@ -1271,7 +1277,7 @@ class Kronolith
     public static function getSyncCalendars($prune = false)
     {
         $haveRemoved = false;
-        $cs = unserialize($GLOBALS['prefs']->getValue('sync_calendars'));
+        $cs = self::_getPrefList('sync_calendars');
         if (!empty($cs)) {
             if ($prune) {
                 $calendars = self::listInternalCalendars(false, Horde_Perms::DELETE);
@@ -1283,7 +1289,8 @@ class Kronolith
                     }
                 }
                 if ($haveRemoved) {
-                    $GLOBALS['prefs']->setValue('sync_calendars', serialize(array_flip($cscopy)));
+                    $cs = array_values(array_flip($cscopy));
+                    self::_setPrefList('sync_calendars', $cs);
                 }
             }
             return $cs;
@@ -1362,7 +1369,7 @@ class Kronolith
      */
     public static function addShare($info)
     {
-        global $calendar_manager, $injector, $prefs, $registry;
+        global $calendar_manager, $injector, $registry;
 
         $kronolith_shares = $injector->getInstance('Kronolith_Shares');
 
@@ -1399,10 +1406,7 @@ class Kronolith
         $all_cals = $calendar_manager->get(Kronolith::ALL_CALENDARS);
         $all_cals[$calendar->getName()] = new Kronolith_Calendar_Internal(['share' => $calendar]);
         $calendar_manager->set(Kronolith::ALL_CALENDARS, $all_cals);
-        $display_cals = $calendar_manager->get(Kronolith::DISPLAY_CALENDARS);
-        $display_cals[] = $calendar->getName();
-        $calendar_manager->set(Kronolith::DISPLAY_CALENDARS, $display_cals);
-        $prefs->setValue('display_cals', serialize($display_cals));
+        self::addCalendarToDisplayCalendarsPref($calendar->getName());
 
         return $calendar;
     }
@@ -1435,6 +1439,8 @@ class Kronolith
 
         $tagger = self::getTagger();
         $tagger->replaceTags($calendar->getName(), $info['tags'], $calendar->get('owner'), Kronolith_Tagger::TYPE_CALENDAR);
+
+        self::notifyActiveSyncOfCalendarChange();
     }
 
     /**
@@ -1453,9 +1459,11 @@ class Kronolith
             throw new Kronolith_Exception(_("You are not allowed to delete this calendar."));
         }
 
+        $calendarId = $calendar->getName();
+
         // Delete the calendar.
         try {
-            self::getDriver()->delete($calendar->getName());
+            self::getDriver()->delete($calendarId);
         } catch (Exception $e) {
             throw new Kronolith_Exception(sprintf(_("Unable to delete \"%s\": %s"), $calendar->get('name'), $e->getMessage()));
         }
@@ -1468,6 +1476,454 @@ class Kronolith
         } catch (Horde_Share_Exception $e) {
             throw new Kronolith_Exception($e);
         }
+
+        self::removeCalendarFromSyncCalendars($calendarId);
+        self::removeCalendarFromDisplayCalendarsPref($calendarId);
+        if (!empty($GLOBALS['calendar_manager'])) {
+            $all = $GLOBALS['calendar_manager']->get(Kronolith::ALL_CALENDARS);
+            unset($all[$calendarId]);
+            $GLOBALS['calendar_manager']->set(Kronolith::ALL_CALENDARS, $all);
+        }
+        self::removeActiveSyncCalendarCollectionsFromDeviceCache($calendarId);
+        self::notifyActiveSyncOfCalendarChange();
+    }
+
+    /**
+     * Reload Kronolith state that is cached in the web PHP session.
+     *
+     * ActiveSync and other RPC clients update preferences and shares in their
+     * own requests; an existing browser session may otherwise keep stale lists
+     * until logout.
+     */
+    public static function refreshWebSessionState()
+    {
+        if ($GLOBALS['registry']->getApp() !== 'kronolith'
+            || empty($GLOBALS['session'])) {
+            return;
+        }
+
+        $cacheTs = self::_getCalendarCacheTimestamp();
+        if (!$cacheTs) {
+            return;
+        }
+
+        $sessionTs = (float)$GLOBALS['session']->get(
+            'kronolith',
+            'calendar_cache_ts'
+        );
+        if ($cacheTs <= $sessionTs) {
+            return;
+        }
+
+        $GLOBALS['prefs']->cleanup();
+        $GLOBALS['prefs']->retrieve();
+
+        $GLOBALS['injector']
+            ->getInstance('Kronolith_Shares')
+            ->expireListCache();
+
+        $calendarIds = array_keys(self::listInternalCalendars());
+        self::_pruneCalendarPrefList('display_cals', $calendarIds);
+        self::getDefaultCalendar(Horde_Perms::EDIT, true);
+        self::getSyncCalendars(true);
+        self::_clearStaleDisplayCalendarSession($calendarIds);
+        self::persistPrefs();
+
+        $GLOBALS['session']->set('kronolith', 'calendar_cache_ts', $cacheTs);
+    }
+
+    /**
+     * Write preference changes to storage immediately.
+     */
+    public static function persistPrefs()
+    {
+        $GLOBALS['prefs']->store();
+    }
+
+    /**
+     * Add a calendar to the display_cals preference.
+     *
+     * @param string $calendarId  Calendar share id.
+     */
+    public static function addCalendarToDisplayCalendarsPref($calendarId)
+    {
+        $display = !empty($GLOBALS['calendar_manager'])
+            ? $GLOBALS['calendar_manager']->get(Kronolith::DISPLAY_CALENDARS)
+            : self::_getPrefList('display_cals');
+        if (in_array($calendarId, $display, true)) {
+            return;
+        }
+
+        $display[] = $calendarId;
+        self::_setPrefList('display_cals', $display);
+        if (!empty($GLOBALS['calendar_manager'])) {
+            $GLOBALS['calendar_manager']->set(Kronolith::DISPLAY_CALENDARS, $display);
+        }
+    }
+
+    /**
+     * Remove a calendar from the display_cals preference.
+     *
+     * @param string $calendarId  Calendar share id.
+     */
+    public static function removeCalendarFromDisplayCalendarsPref($calendarId)
+    {
+        $display = !empty($GLOBALS['calendar_manager'])
+            ? $GLOBALS['calendar_manager']->get(Kronolith::DISPLAY_CALENDARS)
+            : self::_getPrefList('display_cals');
+        $key = array_search($calendarId, $display, true);
+        if ($key === false) {
+            return;
+        }
+
+        unset($display[$key]);
+        $display = array_values($display);
+        self::_setPrefList('display_cals', $display);
+        if (!empty($GLOBALS['calendar_manager'])) {
+            $GLOBALS['calendar_manager']->set(Kronolith::DISPLAY_CALENDARS, $display);
+        }
+    }
+
+    /**
+     * Add a calendar to the sync_calendars preference.
+     *
+     * @param string $calendarId  Calendar share id.
+     */
+    public static function addCalendarToSyncCalendars($calendarId)
+    {
+        $sync = self::_getPrefList('sync_calendars');
+        if (in_array($calendarId, $sync, true)) {
+            return;
+        }
+
+        $sync[] = $calendarId;
+        self::_setPrefList('sync_calendars', $sync);
+    }
+
+    /**
+     * Remove a calendar from the sync_calendars preference.
+     *
+     * @param string $calendarId  Calendar share id.
+     */
+    public static function removeCalendarFromSyncCalendars($calendarId)
+    {
+        $sync = self::_getPrefList('sync_calendars');
+        $key = array_search($calendarId, $sync, true);
+        if ($key === false) {
+            return;
+        }
+
+        unset($sync[$key]);
+        self::_setPrefList('sync_calendars', array_values($sync));
+    }
+
+    /**
+     * Persist calendar prefs and wake ActiveSync after calendar folder changes.
+     *
+     * Folder hierarchy updates are delivered on the device's next FolderSync.
+     * Stored folder/cache mappings are left intact so FolderSync can emit
+     * FolderHierarchy:Add/Update/Delete cleanly.
+     *
+     * @return boolean  True if at least one device was notified.
+     */
+    public static function notifyActiveSyncOfCalendarChange()
+    {
+        self::markCalendarCacheChanged();
+        self::persistPrefs();
+
+        try {
+            return self::requestActiveSyncFolderHierarchySync();
+        } catch (Exception $e) {
+            Horde::log($e);
+            return false;
+        }
+    }
+
+    /**
+     * Mark calendar list data as changed for other web sessions.
+     */
+    public static function markCalendarCacheChanged()
+    {
+        try {
+            $cache = $GLOBALS['injector']->getInstance('Horde_Cache');
+            $timestamp = sprintf('%.6F', microtime(true));
+            foreach (self::_calendarCacheKeysForCurrentUser() as $key) {
+                $cache->set($key, $timestamp, 0);
+            }
+        } catch (Exception $e) {
+            Horde::log($e);
+        }
+    }
+
+    /**
+     * Remove per-device SYNC/PING collection entries for one calendar.
+     *
+     * Folder cache mappings are kept so FolderSync can still deliver
+     * FolderHierarchy:Delete after a web-side delete.
+     *
+     * @param string $calendarId  Calendar share id.
+     *
+     * @return boolean  True if at least one device cache was updated.
+     */
+    public static function removeActiveSyncCalendarCollectionsFromDeviceCache($calendarId)
+    {
+        try {
+            if (!self::_isActiveSyncEnabled()
+                || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
+                return false;
+            }
+
+            $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+            $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+            $sm->setLogger($logger);
+            $devices = self::_listActiveSyncDevicesForUser();
+            if (!count($devices)) {
+                return false;
+            }
+
+            $updated = false;
+            foreach ($devices as $device) {
+                $cache = new Horde_ActiveSync_SyncCache(
+                    $sm,
+                    $device['device_id'],
+                    $device['device_user'],
+                    $logger
+                );
+                if (self::_purgeActiveSyncCalendarCollections($cache, $calendarId)) {
+                    $cache->save();
+                    $updated = true;
+                }
+            }
+
+            return $updated;
+        } catch (Exception $e) {
+            Horde::log($e);
+            return false;
+        }
+    }
+
+    /**
+     * Tell all of a user's devices to run FolderSync on the next request.
+     *
+     * @return boolean  True if at least one device cache was updated.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    public static function requestActiveSyncFolderHierarchySync()
+    {
+        if (!self::_isActiveSyncEnabled()
+            || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
+            return false;
+        }
+
+        $devices = self::_listActiveSyncDevicesForUser();
+        if (!count($devices)) {
+            return false;
+        }
+
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+
+        $updated = false;
+        foreach ($devices as $device) {
+            $cache = new Horde_ActiveSync_SyncCache(
+                $sm,
+                $device['device_id'],
+                $device['device_user'],
+                $logger
+            );
+            if (!count($cache->getFolders()) && !count($cache->getCollections(false))) {
+                continue;
+            }
+
+            $cache->hierarchy = '0';
+            $cache->updateTimestamp();
+            $cache->save();
+            $updated = true;
+        }
+
+        return $updated;
+    }
+
+    /**
+     * @return boolean
+     */
+    protected static function _isActiveSyncEnabled()
+    {
+        return !empty($GLOBALS['conf']['activesync']['enabled']);
+    }
+
+    /**
+     * List ActiveSync devices for the logged-in user.
+     *
+     * @return array  Device rows from Horde_ActiveSync_State::listDevices().
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    protected static function _listActiveSyncDevicesForUser()
+    {
+        $registry = $GLOBALS['registry'];
+        $userIds = array_unique(array_filter([
+            $registry->getAuth(),
+            $registry->getAuth('original'),
+        ]));
+        if (!count($userIds)) {
+            return [];
+        }
+
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+
+        $devices = [];
+        foreach ($userIds as $userId) {
+            foreach ($sm->listDevices($userId) as $device) {
+                $key = $device['device_id'] . "\0" . $device['device_user'];
+                $devices[$key] = $device;
+            }
+        }
+
+        return array_values($devices);
+    }
+
+    /**
+     * @param Horde_ActiveSync_SyncCache $cache
+     * @param string $calendarId
+     *
+     * @return boolean
+     */
+    protected static function _purgeActiveSyncCalendarCollections(
+        Horde_ActiveSync_SyncCache $cache,
+        $calendarId
+    ) {
+        $backendId = Horde_ActiveSync::CLASS_CALENDAR . ':' . $calendarId;
+        $updated = false;
+
+        foreach ($cache->getCollections(false) as $collectionId => $collection) {
+            if (($collection['class'] ?? '') !== Horde_ActiveSync::CLASS_CALENDAR) {
+                continue;
+            }
+            $collBackendId = $collection['serverid'] ?? '';
+            if ($collBackendId === $backendId
+                || $collectionId === $backendId
+                || $collectionId === $calendarId) {
+                $cache->removeCollection($collectionId, true);
+                $updated = true;
+            }
+        }
+
+        return $updated;
+    }
+
+    /**
+     * @param string $pref  Preference name.
+     *
+     * @return array  List of calendar ids.
+     */
+    protected static function _getPrefList($pref)
+    {
+        $list = @unserialize($GLOBALS['prefs']->getValue($pref));
+
+        return is_array($list) ? array_values($list) : [];
+    }
+
+    /**
+     * @param string $pref  Preference name.
+     * @param array  $list  List of calendar ids.
+     */
+    protected static function _setPrefList($pref, array $list)
+    {
+        $GLOBALS['prefs']->setValue($pref, serialize(array_values($list)));
+    }
+
+    /**
+     * Remove stale calendar ids from a serialized calendar preference.
+     *
+     * @param string $pref         Preference name.
+     * @param array  $calendarIds  Existing internal calendar ids.
+     */
+    protected static function _pruneCalendarPrefList($pref, array $calendarIds)
+    {
+        $list = self::_getPrefList($pref);
+        $pruned = array_values(array_intersect($list, $calendarIds));
+        if ($pruned !== $list) {
+            self::_setPrefList($pref, $pruned);
+        }
+    }
+
+    /**
+     * Clear a stale single-calendar web view stored in this PHP session.
+     *
+     * @param array $calendarIds  Existing internal calendar ids.
+     */
+    protected static function _clearStaleDisplayCalendarSession(array $calendarIds)
+    {
+        if (empty($GLOBALS['session'])) {
+            return;
+        }
+
+        $displayCal = $GLOBALS['session']->get('kronolith', 'display_cal');
+        if (!is_string($displayCal) || !strlen($displayCal)) {
+            return;
+        }
+
+        if (strncmp($displayCal, 'internal_', 9) === 0) {
+            $displayCal = substr($displayCal, 9);
+        } elseif (strncmp($displayCal, 'remote_', 7) === 0
+                  || strncmp($displayCal, 'external_', 9) === 0
+                  || strncmp($displayCal, 'resource_', 9) === 0
+                  || strncmp($displayCal, 'holidays_', 9) === 0) {
+            return;
+        }
+
+        if (!in_array($displayCal, $calendarIds, true)) {
+            $GLOBALS['session']->set('kronolith', 'display_cal', '');
+        }
+    }
+
+    /**
+     * Read the current cross-session calendar list marker.
+     *
+     * @return float  Timestamp marker, or 0 if none exists.
+     */
+    protected static function _getCalendarCacheTimestamp()
+    {
+        try {
+            $cache = $GLOBALS['injector']->getInstance('Horde_Cache');
+            $timestamp = 0;
+            foreach (self::_calendarCacheKeysForCurrentUser() as $key) {
+                $value = $cache->get($key, 0);
+                if ($value !== false) {
+                    $timestamp = max($timestamp, (float)$value);
+                }
+            }
+            return $timestamp;
+        } catch (Exception $e) {
+            Horde::log($e);
+            return 0;
+        }
+    }
+
+    /**
+     * Return cache keys for auth ids that may address the same user.
+     *
+     * @return array  Cache keys.
+     */
+    protected static function _calendarCacheKeysForCurrentUser()
+    {
+        $registry = $GLOBALS['registry'];
+        $userIds = array_unique(array_filter([
+            $registry->getAuth(),
+            $registry->getAuth('original'),
+        ]));
+
+        $keys = [];
+        foreach ($userIds as $userId) {
+            $keys[] = self::CALENDAR_CACHE_TS_PREFIX . hash('sha256', $userId);
+        }
+
+        return $keys;
     }
 
     /**


### PR DESCRIPTION
# Kronolith: refresh web calendar lists after ActiveSync folder changes

## Summary

- Add a lightweight cross-session calendar list marker in `Horde_Cache`.
- Refresh Kronolith web-session calendar state only when that marker changes.
- Clear stale calendar preferences and single-calendar session views after external calendar add, rename, or delete.
- Make ActiveSync folder hierarchy notifications best-effort so calendar CRUD is not blocked by device cache issues.

## Problem

Kronolith web UI and `activesync.php` run in separate PHP sessions. When an iOS ActiveSync 16.0 client creates, renames, or deletes a calendar, the persistent share and preference state changes correctly, but an already-open Kronolith web session can keep stale in-memory state.

Observed effects:

- iOS-created or renamed calendars are visible in the web UI only after logout/login.
- iOS-deleted calendars may remain selected in an existing web session.
- If the web UI is focused on a deleted calendar, it can show an "access denied" toast until the stale session is reset.

An earlier Nag approach refreshed prefs and expired list cache on every page load. That fixes correctness, but review feedback pointed out the main drawback: the page-load path becomes unnecessarily expensive.

## Solution

This change keeps the correctness benefit but makes the normal web request path cheap.

When calendar folder state changes, Kronolith now writes a per-user marker to `Horde_Cache`:

- web/API/iOS calendar add
- calendar rename/update
- calendar delete
- `sync_calendars` preference changes

On Kronolith web initialization, the existing PHP session reads only that marker. If it did not change, no prefs reload or share cache expiration runs.

If the marker changed, Kronolith refreshes the stale web-session state:

- reloads preferences from storage,
- expires the `Kronolith_Shares` list cache,
- prunes deleted ids from `display_cals`,
- refreshes/prunes `sync_calendars`,
- refreshes the default calendar if necessary,
- clears a stale `display_cal` session value that points to a deleted internal calendar,
- stores the marker in the current PHP session.

The old implicit `calendar_cache_ts` preference is removed. It is no longer needed because using a preference for the marker would still require loading prefs to detect the change.

## Performance considerations

The steady-state request path now performs only one lightweight `Horde_Cache` read per Kronolith initialization.

The expensive work is conditional and runs only once per active web session after an external calendar list change:

- `$prefs->cleanup()`
- `$prefs->retrieve()`
- `Kronolith_Shares::expireListCache()`
- calendar preference pruning

This addresses the performance concern raised in the Nag review while preserving cross-session correctness.

## ActiveSync behavior

`notifyActiveSyncOfCalendarChange()` still persists preference changes and requests a FolderSync by invalidating the device hierarchy key.

The ActiveSync device-cache notification is now best-effort:

- actual calendar/share changes are applied first,
- ActiveSync cache errors are logged,
- calendar CRUD is not failed just because a device cache update could not be completed.

This also applies to cleanup of deleted-calendar SYNC/PING collections.

## Files changed

### `lib/Kronolith.php`

- Adds `CALENDAR_CACHE_TS_PREFIX`.
- Changes `refreshWebSessionState()` to use a `Horde_Cache` marker before doing expensive refresh work.
- Adds helper methods for:
  - reading the marker,
  - generating per-user marker keys,
  - pruning serialized calendar preference lists,
  - clearing stale `display_cal` session state.
- Changes `markCalendarCacheChanged()` to write the marker into `Horde_Cache`.
- Makes ActiveSync notification and deleted-calendar collection cleanup best-effort.
- Updates `getSyncCalendars()` to use `_getPrefList()` / `_setPrefList()`.

### `config/prefs.php`

- Removes the obsolete implicit `calendar_cache_ts` preference.

## Test plan

- [x] Create calendar on iOS, refresh already-open Kronolith web UI, verify the calendar appears without logout/login.
- [x] Rename calendar on iOS, refresh already-open Kronolith web UI, verify the changed name appears without logout/login.
- [x] Delete calendar on iOS, refresh already-open Kronolith web UI, verify the calendar disappears without logout/login.
- [x] Delete the calendar currently selected in the web UI, refresh, verify the stale single-calendar view is cleared and no persistent "access denied" state remains.
- [x] Run `php -l vendor/horde/kronolith/lib/Kronolith.php`.
- [x] Run `php -l vendor/horde/kronolith/config/prefs.php`.
- [x] Check IDE lints for the changed files.

## Deployment notes

This PR is Kronolith-only. It does not require a new ActiveSync companion change.

It should be deployed after the earlier FolderSync/FolderDelete fixes, because this change assumes calendar folder changes already persist correctly and ActiveSync hierarchy invalidation is functional.
