### PR TITLE
fix(security): restrict unserialize allowed_classes (ZDI-20-1051)

### DIFF
--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -254,7 +254,7 @@ class Kronolith_Attendee implements Serializable
     // TODO: Remove unserialize() - Serializable interface is deprecated
     public function unserialize(string $data)
     {
-        $data = unserialize($data);
+        $data = unserialize($data, ['allowed_classes' => false]);
         $this->__unserialize($data);
     }
 

--- a/lib/Attendee/List.php
+++ b/lib/Attendee/List.php
@@ -274,7 +274,7 @@ class Kronolith_Attendee_List implements ArrayAccess, Countable, IteratorAggrega
      */
     public function unserialize($data)
     {
-        $this->_list = @unserialize($data);
+        $this->_list = @unserialize($data, ['allowed_classes' => ['Kronolith_Attendee']]);
     }
 
     public function __unserialize(array $data): void

--- a/lib/CalendarsManager.php
+++ b/lib/CalendarsManager.php
@@ -295,7 +295,7 @@ class Kronolith_CalendarsManager
             }
 
             foreach ($display_prefs as $key => $val) {
-                $pref_val = @unserialize($prefs->getValue($key));
+                $pref_val = @unserialize($prefs->getValue($key), ['allowed_classes' => false]);
                 $val = '_' . $val;
                 $this->$val = is_array($pref_val)
                     ? $pref_val
@@ -615,7 +615,7 @@ class Kronolith_CalendarsManager
             // Check that all selected remote calendars are still configured.
             $tmp = $this->_displayRemote;
             $this->_allRemote = $this->_displayRemote = [];
-            $calendars = @unserialize($GLOBALS['prefs']->getValue('remote_cals'));
+            $calendars = @unserialize($GLOBALS['prefs']->getValue('remote_cals'), ['allowed_classes' => false]);
             if (!is_array($calendars)) {
                 $calendars = [];
             }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -2813,7 +2813,7 @@ abstract class Kronolith_Event
             $prefs = $GLOBALS['prefs'];
         }
 
-        $methods = !empty($this->methods) ? $this->methods : @unserialize($prefs->getValue('event_alarms'));
+        $methods = !empty($this->methods) ? $this->methods : @unserialize($prefs->getValue('event_alarms'), ['allowed_classes' => false]);
         if (isset($methods['notify'])) {
             $methods['notify']['show'] = [
                 '__app' => $GLOBALS['registry']->getApp(),

--- a/lib/FreeBusy.php
+++ b/lib/FreeBusy.php
@@ -182,7 +182,7 @@ class Kronolith_FreeBusy
         $prefs = $injector->getInstance('Horde_Core_Factory_Prefs')
             ->create('kronolith', ['cache' => false, 'user' => $user]);
         $registry->setTimeZone();
-        $cals = @unserialize($prefs->getValue('fb_cals'));
+        $cals = @unserialize($prefs->getValue('fb_cals'), ['allowed_classes' => false]);
 
         // If the free/busy calendars preference is empty, default to the
         // user's default_share preference, and if that's empty, to their

--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -1147,7 +1147,7 @@ class Kronolith
                 Horde::log($e);
                 return [];
             }
-            $display_calendars = @unserialize($GLOBALS['prefs']->getValue('display_cals'));
+            $display_calendars = @unserialize($GLOBALS['prefs']->getValue('display_cals'), ['allowed_classes' => false]);
             if (is_array($display_calendars)) {
                 foreach ($display_calendars as $id) {
                     try {
@@ -1507,7 +1507,7 @@ class Kronolith
             return;
         }
 
-        $sessionTs = (float)$GLOBALS['session']->get(
+        $sessionTs = (float) $GLOBALS['session']->get(
             'kronolith',
             'calendar_cache_ts'
         );
@@ -1823,7 +1823,7 @@ class Kronolith
      */
     protected static function _getPrefList($pref)
     {
-        $list = @unserialize($GLOBALS['prefs']->getValue($pref));
+        $list = @unserialize($GLOBALS['prefs']->getValue($pref), ['allowed_classes' => false]);
 
         return is_array($list) ? array_values($list) : [];
     }
@@ -1895,7 +1895,7 @@ class Kronolith
             foreach (self::_calendarCacheKeysForCurrentUser() as $key) {
                 $value = $cache->get($key, 0);
                 if ($value !== false) {
-                    $timestamp = max($timestamp, (float)$value);
+                    $timestamp = max($timestamp, (float) $value);
                 }
             }
             return $timestamp;
@@ -3331,7 +3331,7 @@ class Kronolith
      */
     public static function viewShowLocation()
     {
-        $show = @unserialize($GLOBALS['prefs']->getValue('show_location'));
+        $show = @unserialize($GLOBALS['prefs']->getValue('show_location'), ['allowed_classes' => false]);
         return @in_array('screen', $show);
     }
 
@@ -3340,7 +3340,7 @@ class Kronolith
      */
     public static function viewShowTime()
     {
-        $show = @unserialize($GLOBALS['prefs']->getValue('show_time'));
+        $show = @unserialize($GLOBALS['prefs']->getValue('show_time'), ['allowed_classes' => false]);
         return @in_array('screen', $show);
     }
 


### PR DESCRIPTION
## Summary

Follow-up to horde/imp#7

- All bare `@unserialize()` calls on prefs data now pass `allowed_classes` restrictions
- Pure data prefs (fb_cals, display_cals, remote_cals, show_location, show_time, event_alarms, calendar display prefs) use `allowed_classes => false` to prevent object instantiation
- `Kronolith_Attendee_List::unserialize()` whitelists only `Kronolith_Attendee`
- `Kronolith_Attendee::unserialize()` restricted to data-only (its serialized form is a plain array)