### PR TITLE
fix(kronolith): harden EAS 16.0 recurring calendar instance sync

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -1140,6 +1140,11 @@ class Kronolith_Api extends Horde_Registry_Api
             $deleteDate = ($recurrenceId instanceof Horde_Date)
                 ? $recurrenceId
                 : new Horde_Date($recurrenceId);
+
+            // EAS 16.0 may have created a bound exception for this instance.
+            $event->deleteBoundExceptionForInstance($deleteDate);
+
+            $deleteDate->setTimezone($event->timezone ?: date_default_timezone_get());
             $event->recurrence->addException($deleteDate->format('Y'), $deleteDate->format('m'), $deleteDate->format('d'));
             $event->save();
         } elseif ($range == Kronolith::RANGE_THISANDFUTURE) {

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -1675,6 +1675,73 @@ abstract class Kronolith_Event
     }
 
     /**
+     * Normalize an EAS InstanceId to a UTC Horde_Date.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param Horde_Date|string|null $instanceid
+     *
+     * @return Horde_Date|null
+     */
+    protected function _easInstanceIdToUtcDate($instanceid): ?Horde_Date
+    {
+        if ($instanceid instanceof Horde_Date) {
+            $date = clone $instanceid;
+        } elseif (is_string($instanceid) && $instanceid !== '') {
+            try {
+                $date = new Horde_Date($instanceid, 'UTC');
+            } catch (Horde_Date_Exception $e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
+        $date->setTimezone('UTC');
+
+        return $date;
+    }
+
+    /**
+     * Compare two EAS InstanceId values for the same occurrence.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param Horde_Date|string|null $a
+     * @param Horde_Date|string|null $b
+     *
+     * @return boolean
+     */
+    protected function _easInstanceIdsEqual($a, $b): bool
+    {
+        $da = $this->_easInstanceIdToUtcDate($a);
+        $db = $this->_easInstanceIdToUtcDate($b);
+
+        return $da && $db
+            && $da->format('Ymd\THis\Z') === $db->format('Ymd\THis\Z');
+    }
+
+    /**
+     * Delete a bound exception event for a recurring-series instance.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param Horde_Date|string|null $instanceid
+     */
+    public function deleteBoundExceptionForInstance($instanceid): void
+    {
+        if (!$this->_easInstanceIdToUtcDate($instanceid)) {
+            return;
+        }
+
+        foreach ($this->boundExceptions() as $exception) {
+            if ($this->_easInstanceIdsEqual($exception->exceptionoriginaldate, $instanceid)) {
+                $this->getDriver()->deleteEvent($exception->id);
+            }
+        }
+    }
+
+    /**
      * Handle adding/editing exceptions from EAS 16.0 clients.
      *
      * @param  Horde_ActiveSync_Message_Appointment $message
@@ -1686,29 +1753,32 @@ abstract class Kronolith_Event
         if (!$this->recurs()) {
             return false;
         }
-        $tz = $message->getTimezone();
+
+        $originalUtc = $this->_easInstanceIdToUtcDate($message->instanceid);
+        if (!$originalUtc) {
+            return false;
+        }
+
+        // EAS 16.0 exception MODIFY often omits Timezone; use the series tz.
+        if (!$message->isGhosted('timezone') && !empty($message->timezone)) {
+            try {
+                $tz = $message->getTimezone();
+            } catch (Horde_Mapi_Exception $e) {
+                $tz = $this->timezone;
+            }
+        } else {
+            $tz = $this->timezone;
+        }
         if (empty($tz)) {
             $tz = date_default_timezone_get();
         }
         $kronolith_driver = $this->getDriver();
 
-        // Do we already have an exception for this day? If so, remove the
-        // bound exception (but don't need to remove it from the recurrence
-        // object since we are just replacing it).
-        $search = new StdClass();
-        $search->baseid = $this->uid;
-        $results = $kronolith_driver->search($search);
-        foreach ($results as $days) {
-            foreach ($days as $exception) {
-                if ($exception->exceptionoriginaldate->setTimezone('UTC')->format('Ymd\THis\Z') == $message->instanceid) {
-                    $kronolith_driver->deleteEvent($exception->id);
-                    break;
-                }
-            }
-        }
+        // Replace any existing bound exception for this instance.
+        $this->deleteBoundExceptionForInstance($originalUtc);
 
         // Ensure the exception is added to the recurrence object.
-        $original = new Horde_Date($message->instanceid, 'UTC');
+        $original = clone $originalUtc;
         $original->setTimezone($tz);
         $this->recurrence->addException($original->format('Y'), $original->format('m'), $original->format('d'));
 
@@ -1730,13 +1800,17 @@ abstract class Kronolith_Event
         $event->description = $message->getBody();
         $event->description = empty($event->description) ? $this->description : $event->description;
         $event->baseid = $this->uid;
-        $event->exceptionoriginaldate = new Horde_Date($message->instanceid, 'UTC');
+        $event->exceptionoriginaldate = clone $originalUtc;
         $event->exceptionoriginaldate->setTimezone($tz);
         $event->initialized = true;
         if ($tz != date_default_timezone_get()) {
             $event->timezone = $tz;
         }
         $event->save();
+
+        // Persist the master's recurrence exception list so the base
+        // occurrence is suppressed on export.
+        $this->save();
 
         return true;
     }


### PR DESCRIPTION
# fix(kronolith): harden EAS 16.0 recurring calendar instance sync

## Summary

Fix recurring-series **instance modify** and **instance delete** for **EAS 16.0** ActiveSync clients (tested with iPhone). Ensures bound exceptions, recurrence exception lists, and deleted-instance export stay consistent.

Companion PRs: **activesync** (InstanceId parsing in `Sync.php`), **mapi** (timezone offset guard).

## Problem

EAS 16.0 handles recurring calendar exceptions differently from earlier protocol versions:

- Exception edits arrive as orphaned `SYNC_MODIFY` with `InstanceId` outside `<Data>`
- Instance deletes use `SYNC_REMOVE` + `InstanceId`, not full event deletion
- iOS often omits `Timezone` on exception MODIFY

Several bugs affected production sync:

| Issue | Symptom |
|-------|---------|
| Master event not saved after exception MODIFY | Base occurrence still visible; recurrence exceptions not persisted |
| Bound exception not removed on instance delete | Deleted modified instance still exported as changed exception instead of `Deleted=1` |
| Fragile InstanceId comparison | String vs `Horde_Date` mismatch when replacing bound exceptions |
| Unconditional `getTimezone()` on empty blob | Hundreds of `bias`/`stdbias` warnings in `horde.log` (see mapi PR) |

## Solution

### `lib/Kronolith/Event.php`

- **`_easInstanceIdToUtcDate()`** — normalize InstanceId (string or `Horde_Date`) to UTC
- **`_easInstanceIdsEqual()`** — reliable comparison for matching bound exceptions
- **`deleteBoundExceptionForInstance()`** — remove Kronolith exception events (`baseid`) for a given instance
- **`_handleEas16Exception()`** improvements:
  - Validate InstanceId before processing
  - Use series timezone when client omits Timezone (ghosted/empty)
  - Replace existing bound exception via `deleteBoundExceptionForInstance()`
  - **`$this->save()`** on master after updating recurrence exceptions
  - Clone UTC InstanceId for `exceptionoriginaldate` (no double timezone shift)

### `lib/Kronolith/Api.php`

- **`delete()`** — when deleting a single recurrence instance (`$recurrenceId` set), call `deleteBoundExceptionForInstance()` before `recurrence->addException()` so modified-then-deleted instances export as `POOMCAL:Deleted` exceptions

## Verified behaviour (iPhone EAS 16.0)

Series `Testserie2` (daily recurrence):

- [x] Modify single instance → bound exception created, series intact
- [x] Delete modified instance (`20260613T070000Z`) → `Deleted=1` in sync response
- [x] Delete unmodified instance (`20260615T070000Z`) → `Deleted=1` in sync response
- [x] Device log: `SYNC_REMOVE` + `InstanceId`, status 1, synckey increment, no HTTP 500
- [x] iPhone calendar matches server state

## Example sync flow (delete unmodified instance)

**Request:**
```xml
<Remove>
  <ServerEntryId>…uid…</ServerEntryId>
  <InstanceId>20260615T070000Z</InstanceId>
</Remove>
```

**Response:**
```xml
<Modify>
  <Data>
    <Subject>Testserie2</Subject>
    <Recurrence>…</Recurrence>
    <Exceptions>
      <Exception>
        <Deleted>1</Deleted>
        <InstanceId>20260613T070000Z</InstanceId>
      </Exception>
      <Exception>
        <Deleted>1</Deleted>
        <InstanceId>20260615T070000Z</InstanceId>
      </Exception>
    </Exceptions>
  </Data>
</Modify>
```

## Files changed

| File | Changes |
|------|---------|
| `lib/Event.php` | InstanceId helpers, `_handleEas16Exception()` rewrite |
| `lib/Api.php` | Bound exception cleanup on instance delete |

## Test plan

- [ ] Create daily/weekly recurring event via iOS
- [ ] Modify one instance (time/title) → verify in Kronolith web UI and re-sync
- [ ] Delete modified instance → verify `Deleted` exception, instance gone on phone
- [ ] Delete unmodified instance → same
- [ ] `horde.log`: no timezone warnings on exception MODIFY (with mapi PR applied)
- [ ] `php -l` on modified files passes

## Related / follow-up

- **activesync**: parse `InstanceId` to `Horde_Date` in `Sync.php` on calendar MODIFY
- **mapi**: guard `_checkTransition()` against incomplete offset arrays
- **Deferred**: `SYNC_FETCH` with `InstanceId` (not yet implemented)

## Commit message

```
fix(kronolith): harden EAS 16.0 recurring calendar instance sync

Normalize InstanceId handling, persist master recurrence on exception
modify, remove bound exceptions when deleting instances, and avoid
getTimezone() on empty timezone blobs from iOS exception MODIFY.
```
