### PR TITLE
fix(kronolith): persist calendar visibility and fix attendee event dialog

### DIFF
--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -28,6 +28,8 @@ KronolithCore = {
     loading: 0,
     viewLoading: [],
     fbLoading: 0,
+    // One free/busy column per hour; matches edit.inc thead (0h–23h).
+    FB_HOURS_PER_DAY: 24,
     redBoxLoading: false,
     date: Date.today(),
     tasktype: 'incomplete',
@@ -5850,12 +5852,8 @@ KronolithCore = {
         this.fbLoading = 0;
         this.freeBusyRows = $H();
         this.freeBusyData = $H();
-        if ($('kronolithEventAttendeesList')) {
-            $('kronolithEventAttendeesList').down('tbody').update();
-        }
-        if ($('kronolithEventResourcesList')) {
-            $('kronolithEventResourcesList').down('tbody').update();
-        }
+        this._clearFBTableBody('kronolithEventAttendeesList');
+        this._clearFBTableBody('kronolithEventResourcesList');
         $('kronolithFBLoading').hide();
         $('kronolithResourceFBLoading').hide();
         this.updateCalendarDropDown('kronolithEventTarget');
@@ -6631,19 +6629,59 @@ KronolithCore = {
     },
 
     /**
+     * Returns the tbody of a free/busy attendee/resource list table.
+     *
+     * @param string listId  Element id of the list container div.
+     *
+     * @return Element|null  The tbody element or null.
+     */
+    _getFBTableBody: function(listId)
+    {
+        var list = document.getElementById(listId);
+
+        return list ? list.querySelector('tbody') : null;
+    },
+
+    /**
+     * Removes all rows from a free/busy list table.
+     *
+     * @param string listId  Element id of the list container div.
+     */
+    _clearFBTableBody: function(listId)
+    {
+        var tbody = this._getFBTableBody(listId);
+
+        if (tbody) {
+            tbody.innerHTML = '';
+        }
+    },
+
+    /**
+     * Appends a row to a free/busy list table.
+     *
+     * @param string listId  Element id of the list container div.
+     * @param Element row    The TR element to append.
+     */
+    _insertFBTableRow: function(listId, row)
+    {
+        var tbody = this._getFBTableBody(listId);
+
+        if (tbody) {
+            tbody.appendChild(row);
+        }
+    },
+
+    /**
      * Adds an attendee row to the free/busy table.
      *
      * @param object attendee  An attendee object.
      */
     insertFBRow: function(attendee)
     {
-        var tr = new Element('tr'), response, i;
+        var tr = new Element('tr');
         this.freeBusyRows.set(attendee.i, tr);
         this.updateFBRow(attendee, tr);
-        var attendeesList = $('kronolithEventAttendeesList');
-        if (attendeesList) {
-            attendeesList.down('tbody').insert(tr);
-        }
+        this._insertFBTableRow('kronolithEventAttendeesList', tr);
     },
 
     /**
@@ -6662,7 +6700,7 @@ KronolithCore = {
                 tdone = row.down('td');
             row.update();
             row.update(tdone);
-            for (i = 0; i < 24; i++) {
+            for (i = 0; i < this.FB_HOURS_PER_DAY; i++) {
                 row.insert(new Element('td', { className: 'kronolithFBUnknown' }));
             }
         }.bind(this));
@@ -6684,7 +6722,7 @@ KronolithCore = {
             case 4: response = 'Tentative'; break;
         }
         row.insert(this.getAttendeeCell(attendee, response));
-        for (var i = 0; i < 24; i++) {
+        for (var i = 0; i < this.FB_HOURS_PER_DAY; i++) {
             row.insert(new Element('td', { className: 'kronolithFBUnknown' }));
         }
     },
@@ -6770,10 +6808,10 @@ KronolithCore = {
                 title: resource,
                 className: 'kronolithAttendee' + response
             }).update(resource.escapeHTML()));
-            for (i = 0; i < 24; i++) {
+            for (i = 0; i < this.FB_HOURS_PER_DAY; i++) {
                 tr.insert(new Element('td', { className: 'kronolithFBUnknown' }));
             }
-            $('kronolithEventResourcesList').down('tbody').insert(tr);
+            this._insertFBTableRow('kronolithEventResourcesList', tr);
             this.resourceACCache.map.set(resource, v);
             $('kronolithEventResourceIds').value = this.resourceACCache.map.values();
         } else {

--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -5814,6 +5814,9 @@ KronolithCore = {
 
     editEvent: function(calendar, id, date, title)
     {
+        if (this.redBoxLoading && !RedBox.getWindow()) {
+            this.redBoxLoading = false;
+        }
         if (this.redBoxLoading) {
             return;
         }
@@ -5844,6 +5847,17 @@ KronolithCore = {
         HordeImple.AutoCompleter.kronolithEventAttendees.reset();
         this.attendees = [];
         this.resources = [];
+        this.fbLoading = 0;
+        this.freeBusyRows = $H();
+        this.freeBusyData = $H();
+        if ($('kronolithEventAttendeesList')) {
+            $('kronolithEventAttendeesList').down('tbody').update();
+        }
+        if ($('kronolithEventResourcesList')) {
+            $('kronolithEventResourcesList').down('tbody').update();
+        }
+        $('kronolithFBLoading').hide();
+        $('kronolithResourceFBLoading').hide();
         this.updateCalendarDropDown('kronolithEventTarget');
         this.toggleAllDay(false);
         this.openTab($('kronolithEventForm').down('.tabset a.kronolithTabLink'));
@@ -5875,9 +5889,9 @@ KronolithCore = {
             var events = this.getCacheForDate(date.toString('yyyyMMdd'), calendar);
             if (events) {
                 var ev = events.find(function(e) { return e.key == id; });
-                if (ev[1].r) {
-                    attributes.rsd = ev[1].start.dateString();
-                    attributes.red = ev[1].end.dateString();
+                if (ev && ev.value && ev.value.r && ev.value.start && ev.value.end) {
+                    attributes.rsd = ev.value.start.dateString();
+                    attributes.red = ev.value.end.dateString();
                 }
             }
             HordeCore.doAction('getEvent', attributes, {
@@ -6135,9 +6149,9 @@ KronolithCore = {
      */
     editEventCallback: function(r)
     {
+        try {
         if (!r.event) {
             RedBox.close();
-            this.go(this.lastLocation);
             return;
         }
 
@@ -6153,7 +6167,9 @@ KronolithCore = {
         $('kronolithEventId').setValue(ev.id);
         $('kronolithEventCalendar').setValue(ev.ty + '|' + ev.c);
         $('kronolithEventTarget').setValue(ev.ty + '|' + ev.c);
-        $('kronolithEventTargetRO').update(Kronolith.conf.calendars[ev.ty][ev.c].name.escapeHTML());
+        if (Kronolith.conf.calendars[ev.ty] && Kronolith.conf.calendars[ev.ty][ev.c]) {
+            $('kronolithEventTargetRO').update(Kronolith.conf.calendars[ev.ty][ev.c].name.escapeHTML());
+        }
         $('kronolithEventTitle').setValue(ev.t);
         $('kronolithEventLocation').setValue(ev.l);
         $('kronolithEventTimezone').setValue(ev.tz);
@@ -6205,7 +6221,10 @@ KronolithCore = {
 
         $('kronolithEventStartTime').setValue(ev.st);
         this.knl.kronolithEventStartTime.setSelected(ev.st);
-        this.updateFBDate(Date.parseExact(ev.sd, Kronolith.conf.date_format));
+        var fbDate = Date.parseExact(ev.sd, Kronolith.conf.date_format);
+        if (fbDate) {
+            this.updateFBDate(fbDate);
+        }
         $('kronolithEventEndTime').setValue(ev.et);
         this.knl.kronolithEventEndTime.setSelected(ev.et);
         this.duration = Math.abs(Date.parse(ev.e).getTime() - Date.parse(ev.s).getTime()) / 60000;
@@ -6240,8 +6259,12 @@ KronolithCore = {
                         $('kronolithEventAlarm' + method.key + 'Params').show();
                         $H(method.value).each(function(param) {
                             var input = $('kronolithEventAlarmParam' + param.key);
-                            if (input.type == 'radio') {
-                                input.up('form').select('input[type=radio]').each(function(radio) {
+                            if (input && input.type == 'radio') {
+                                var form = input.up('form');
+                                if (!form) {
+                                    return;
+                                }
+                                form.select('input[type=radio]').each(function(radio) {
                                     if (radio.name == input.name &&
                                         radio.value == param.value) {
                                         radio.setValue(1);
@@ -6286,37 +6309,47 @@ KronolithCore = {
             this.recurs = false;
         }
 
-        /* Attendees */
-        if (typeof ev.at !== 'undefined') {
-            let emailFilter = function (attendee) {return !!attendee.e}
-            let emails = [];
-            ev.at.findAll(emailFilter).each(function(foundUser) {
-                if (foundUser.l && foundUser.l !== foundUser.e) {
-                    emails.push('"' + foundUser.l +'"' + ' <' + foundUser.e + '>');
-                } else {
-                    emails.push(foundUser.e);
-                }
-                
-            });
-            HordeImple.AutoCompleter.kronolithEventAttendees.reset(emails);
+        this.setTitle(ev.t);
+        this.redBoxLoading = true;
+        RedBox.showHtml($('kronolithEventDialog').show());
 
-            let userFilter = function(attendee) { return !!attendee.u; }
-            let users = [];
-            /* We need to feed the full user string here.
-               Feeding only the caption will produce errors on re-saving existing events
-               as soon as the name is not the username
-            */
-            ev.at.findAll(userFilter).each(function(foundUser) {
-                users.push(foundUser.l + ' [' + foundUser.u + ']');
-            });
-            users = users.map(function(u){
-                return u.replace(',', '');
-            });
-            HordeImple.AutoCompleter.kronolithEventUsers.reset(users);
-            
-            ev.at.each(this.addAttendee.bind(this));
-            if (this.fbLoading) {
-                $('kronolithFBLoading').show();
+        /* Attendees */
+        if (ev.at) {
+            try {
+                var attendees = $A(ev.at), emailFilter, emails, userFilter, users;
+                emailFilter = function (attendee) { return !!attendee.e; };
+                emails = [];
+                attendees.findAll(emailFilter).each(function(foundUser) {
+                    if (foundUser.l && foundUser.l !== foundUser.e) {
+                        emails.push('"' + foundUser.l + '" <' + foundUser.e + '>');
+                    } else {
+                        emails.push(foundUser.e);
+                    }
+                });
+                HordeImple.AutoCompleter.kronolithEventAttendees.reset(emails);
+
+                userFilter = function(attendee) { return !!attendee.u; };
+                users = [];
+                /* We need to feed the full user string here.
+                   Feeding only the caption will produce errors on re-saving existing events
+                   as soon as the name is not the username
+                */
+                attendees.findAll(userFilter).each(function(foundUser) {
+                    users.push((foundUser.l || foundUser.u) + ' [' + foundUser.u + ']');
+                });
+                users = users.map(function(u) {
+                    return u.replace(',', '');
+                });
+                HordeImple.AutoCompleter.kronolithEventUsers.reset(users);
+
+                attendees.each(this.addAttendee.bind(this));
+                if (this.fbLoading) {
+                    $('kronolithFBLoading').show();
+                }
+            } catch (attendeeError) {
+                if (typeof console !== 'undefined' && console.error) {
+                    console.error('editEventCallback attendees', attendeeError);
+                }
             }
         }
 
@@ -6363,10 +6396,6 @@ KronolithCore = {
             $('kronolithEventTargetRO').show();
         }
 
-        this.setTitle(ev.t);
-        this.redBoxLoading = true;
-        RedBox.showHtml($('kronolithEventDialog').show());
-
         /* Hide alarm message for this event. */
         if (r.msgs) {
             r.msgs = r.msgs.reject(function(msg) {
@@ -6384,6 +6413,15 @@ KronolithCore = {
                 }
                 return false;
             });
+        }
+        } catch (e) {
+            if (RedBox.getWindow()) {
+                RedBox.close();
+            }
+            if (typeof console !== 'undefined' && console.error) {
+                console.error('editEventCallback', e);
+            }
+            throw e;
         }
     },
 
@@ -6602,7 +6640,10 @@ KronolithCore = {
         var tr = new Element('tr'), response, i;
         this.freeBusyRows.set(attendee.i, tr);
         this.updateFBRow(attendee, tr);
-        $('kronolithEventAttendeesList').down('tbody').insert(tr);
+        var attendeesList = $('kronolithEventAttendeesList');
+        if (attendeesList) {
+            attendeesList.down('tbody').insert(tr);
+        }
     },
 
     /**
@@ -6643,16 +6684,15 @@ KronolithCore = {
             case 4: response = 'Tentative'; break;
         }
         row.insert(this.getAttendeeCell(attendee, response));
-        for (i = 0; i < 24; i++) {
+        for (var i = 0; i < 24; i++) {
             row.insert(new Element('td', { className: 'kronolithFBUnknown' }));
         }
     },
 
     getAttendeeCell: function(attendee, response)
     {
-        var className, title;
+        var className = 'kronolithAttendee', title = '';
 
-        className = 'kronolithAttendee';
         if (attendee.u) {
             title = attendee.u;
         } else if (attendee.e) {
@@ -6660,15 +6700,17 @@ KronolithCore = {
         }
         if (attendee.o) {
             className += 'Organizer';
-            title += ' (' + Kronolith.text.organizer + ') ';
+            title = title
+                ? title + ' (' + Kronolith.text.organizer + ')'
+                : Kronolith.text.organizer;
         } else {
             className += response;
         }
 
-        return new Element('td')
-            .writeAttribute('title', title)
-            .classList.add(className)
-            .insert(attendee.l.escapeHTML());
+        return new Element('td', {
+            className: className,
+            title: title
+        }).update((attendee.l || title || '').escapeHTML());
     },
 
     addResourceTabLink: function()
@@ -6724,10 +6766,10 @@ KronolithCore = {
             });
             tr = new Element('tr');
             this.freeBusyRows.set(resource, tr);
-            tr.insert(new Element('td')
-                .writeAttribute('title', resource)
-                .classList.add('kronolithAttendee' + response)
-                .insert(resource.escapeHTML()));
+            tr.insert(new Element('td', {
+                title: resource,
+                className: 'kronolithAttendee' + response
+            }).update(resource.escapeHTML()));
             for (i = 0; i < 24; i++) {
                 tr.insert(new Element('td', { className: 'kronolithFBUnknown' }));
             }
@@ -7484,6 +7526,8 @@ KronolithCore = {
      */
     closeRedBox: function()
     {
+        this.redBoxLoading = false;
+        this.fbLoading = 0;
         if (!RedBox.getWindow()) {
             return;
         }

--- a/lib/Ajax/Application/Handler.php
+++ b/lib/Ajax/Application/Handler.php
@@ -959,7 +959,20 @@ class Kronolith_Ajax_Application_Handler extends Horde_Core_Ajax_Application_Han
             $res = $rfc822->parseAddressList($this->vars->email);
             if ($res[0] && $res[0]->host) {
                 try {
-                    $result->fb = Kronolith_FreeBusy::get($this->vars->email, true);
+                    $email = $res[0]->bare_address;
+                    $user = Kronolith_FreeBusy::getUserFromEmail($email);
+                    if ($user) {
+                        $result->fb = Kronolith_FreeBusy::getForUser(
+                            $user,
+                            [
+                                'json'  => true,
+                                'start' => $this->vars->start,
+                                'end'   => $this->vars->end,
+                            ]
+                        );
+                    } else {
+                        $result->fb = Kronolith_FreeBusy::get($this->vars->email, true);
+                    }
                 } catch (Exception $e) {
                     $notification->push($e->getMessage(), 'horde.warning');
                 }
@@ -1391,11 +1404,26 @@ class Kronolith_Ajax_Application_Handler extends Horde_Core_Ajax_Application_Han
     }
 
     /**
-     * TODO
+     * Persist calendar display preferences from the dynamic interface.
+     *
+     * The toggle itself is applied in
+     * Kronolith_CalendarsManager::_checkToggleCalendars() during
+     * Kronolith::initialize(), which runs on every AJAX request. Calling
+     * toggleDisplayCalendar() here as well would undo the change.
      */
     public function saveCalPref()
     {
-        return false;
+        if (empty($this->vars->toggle_calendar)) {
+            return false;
+        }
+
+        if (empty($GLOBALS['calendar_manager'])) {
+            Kronolith::initialize();
+        }
+
+        Kronolith::persistPrefs();
+
+        return true;
     }
 
     /**

--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -210,6 +210,30 @@ class Kronolith_Attendee implements Serializable
     }
 
     /**
+     * Returns the attendee's email address for transport.
+     *
+     * @return string  The bare email address, or an empty string.
+     */
+    public function getEmailAddress()
+    {
+        if (strlen($this->email)) {
+            return $this->addressObject->bare_address;
+        }
+
+        if (strlen($this->user)) {
+            $identity = $GLOBALS['injector']
+                ->getInstance('Horde_Core_Factory_Identity')
+                ->create($this->user);
+            $email = $identity->getValue('from_addr');
+            if (strlen($email)) {
+                return $email;
+            }
+        }
+
+        return '';
+    }
+
+    /**
      * Returns a simple object suitable for JSON transport representing this
      * attendee.
      *
@@ -219,7 +243,7 @@ class Kronolith_Attendee implements Serializable
     {
         return (object) [
             'a' => intval($this->role),
-            'e' => $this->addressObject->bare_address,
+            'e' => $this->getEmailAddress(),
             'i' => $this->id,
             'l' => strval($this->displayName),
             'r' => intval($this->response),

--- a/lib/CalendarsManager.php
+++ b/lib/CalendarsManager.php
@@ -318,10 +318,22 @@ class Kronolith_CalendarsManager
      */
     protected function _checkToggleCalendars()
     {
+        if (($calId = Util::getFormData('toggle_calendar')) !== null) {
+            $this->toggleDisplayCalendar($calId);
+        }
+    }
+
+    /**
+     * Toggle a calendar's display state and persist the preference.
+     *
+     * @param string $calId  Calendar identifier, optionally prefixed with the
+     *                       calendar type.
+     */
+    public function toggleDisplayCalendar($calId)
+    {
         global $prefs, $registry;
 
-        if (($calId = Util::getFormData('toggle_calendar')) !== null) {
-            if (strncmp($calId, 'remote_', 7) === 0) {
+        if (strncmp($calId, 'remote_', 7) === 0) {
                 $calId = substr($calId, 7);
                 if (($key = array_search($calId, $this->_displayRemote)) === false) {
                     $this->_displayRemote[] = $calId;
@@ -375,7 +387,6 @@ class Kronolith_CalendarsManager
             }
 
             $prefs->setValue('display_cals', serialize($this->_displayCalendars));
-        }
     }
 
     /**

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -3139,18 +3139,19 @@ abstract class Kronolith_Event
                 if (count($this->attendees)) {
                     $attendees = [];
                     foreach ($this->attendees as $attendee) {
-                        if (Kronolith::isUserEmail($this->creator, $attendee->email)) {
+                        $attendeeEmail = $attendee->getEmailAddress();
+                        if ($attendeeEmail
+                            && Kronolith::isUserEmail($this->creator, $attendeeEmail)) {
                             $json->cr = intval($attendee->response);
                         }
                         $attendeeJson = $attendee->toJson();
                         $attendeeJson->o
                             = ($json->oy
-                             && Kronolith::isUserEmail(
-                                 $this->creator,
-                                 $attendee->addressObject->bare_address
-                             ))
+                             && $attendeeEmail
+                             && Kronolith::isUserEmail($this->creator, $attendeeEmail))
                             || (!empty($this->organizer)
-                             && $this->organizer == $attendee->addressObject->bare_address);
+                             && $attendeeEmail
+                             && $this->organizer == $attendeeEmail);
                         $attendees[] = $attendeeJson;
                     }
                     $json->at = $attendees;

--- a/lib/FreeBusy.php
+++ b/lib/FreeBusy.php
@@ -234,6 +234,12 @@ class Kronolith_FreeBusy
 
         $email = $tmp->bare_address;
 
+        /* Local Horde users have free/busy data even without a URL in the
+         * address book. */
+        if ($user = self::getUserFromEmail($email)) {
+            return self::getForUser($user, ['json' => $json]);
+        }
+
         /* Check if we can retrieve a VFB from the Free/Busy URL, if one is
          * set. */
         $url = self::getUrl($email);
@@ -292,6 +298,48 @@ class Kronolith_FreeBusy
             }
             throw new Kronolith_Exception(sprintf(_("No free/busy url found for %s."), $email));
         }
+    }
+
+    /**
+     * Returns the Horde user name for an email address, if any.
+     *
+     * @param string $email  An email address.
+     *
+     * @return string|null  A user name or null if not found.
+     */
+    public static function getUserFromEmail($email)
+    {
+        global $injector;
+
+        static $map = [];
+
+        if (array_key_exists($email, $map)) {
+            return $map[$email];
+        }
+
+        $auth = $injector->getInstance('Horde_Core_Factory_Auth')->create();
+
+        if (strpos($email, '@') === false) {
+            try {
+                $map[$email] = $auth->exists($email) ? $email : null;
+            } catch (Horde_Auth_Exception $e) {
+                $map[$email] = null;
+            }
+            return $map[$email];
+        }
+
+        try {
+            foreach ($auth->listUsers() as $user) {
+                if (Kronolith::isUserEmail($user, $email)) {
+                    $map[$email] = $user;
+                    return $user;
+                }
+            }
+        } catch (Horde_Auth_Exception $e) {
+        }
+
+        $map[$email] = null;
+        return null;
     }
 
     /**

--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -2532,12 +2532,20 @@ class Kronolith
                     $method = 'REQUEST';
                     if ($attendee->response == self::RESPONSE_NONE) {
                         /* Invitation. */
-                        $filename = 'event-invitation.ics';
+                        $filename = self::_itipIcsFilename(
+                            $event->getTitle(),
+                            '',
+                            'event-invitation.ics'
+                        );
                         $view->subject = $event->getTitle();
                         $view->header = sprintf(_("%s wishes to make you aware of \"%s\"."), $ident->getName(), $event->getTitle());
                     } else {
                         /* Update. */
-                        $filename = 'event-update.ics';
+                        $filename = self::_itipIcsFilename(
+                            $event->getTitle(),
+                            'Updated',
+                            'event-update.ics'
+                        );
                         $view->subject = sprintf(_("Updated: %s."), $event->getTitle());
                         $view->header = sprintf(_("%s wants to notify you about changes of \"%s\"."), $ident->getName(), $event->getTitle());
                     }
@@ -2882,6 +2890,38 @@ class Kronolith
         }
 
         return false;
+    }
+
+    /**
+     * Build a safe .ics attachment filename from an event title.
+     *
+     * @param string $title     Event title.
+     * @param string $prefix    Optional prefix (e.g. "Updated").
+     * @param string $fallback  Filename if the title is empty after sanitizing.
+     *
+     * @return string
+     */
+    protected static function _itipIcsFilename(
+        $title,
+        $prefix = '',
+        $fallback = 'event.ics'
+    ) {
+        $basename = preg_replace('/[\/\\\\:*?"<>|]+/', '', $title);
+        $basename = preg_replace('/\s+/u', ' ', trim($basename));
+        $basename = str_replace(' ', '-', $basename);
+        if (function_exists('mb_substr')) {
+            $basename = mb_substr($basename, 0, 200);
+        } else {
+            $basename = substr($basename, 0, 200);
+        }
+        if ($basename === '') {
+            return $fallback;
+        }
+        if ($prefix !== '') {
+            $basename = $prefix . '-' . $basename;
+        }
+
+        return $basename . '.ics';
     }
 
     /**


### PR DESCRIPTION
# Fix Kronolith calendar visibility persistence and event attendee UX

## Summary

This PR fixes several Kronolith dynamic-view issues reported during day-to-day use:

- **Calendar visibility** no longer resets when leaving Kronolith and returning from another Horde app.
- **Event editing** opens reliably for events with attendees; the dialog no longer aborts silently or becomes impossible to reopen after cancel.
- **Free/busy lookup** resolves local Horde users by email instead of only searching Turba for an external free/busy URL.

## Changes

### Persist calendar display preferences (`saveCalPref`)

- Implement `saveCalPref` in the AJAX handler so calendar show/hide actions from the sidebar are written to `display_cals`.
- Extract `toggleDisplayCalendar()` from `Kronolith_CalendarsManager` for reuse.
- **Important:** do not toggle twice on `saveCalPref` requests. `Kronolith::initialize()` already applies `toggle_calendar` via `_checkToggleCalendars()` during AJAX `appInit`, so calling `toggleDisplayCalendar()` again in `saveCalPref` undid the user action before persistence.

### Event dialog / attendees (JavaScript)

- Guard recurring-event cache lookup in `editEvent` when the event is missing from the client cache (`ev && ev.value`).
- Reset free/busy UI state when opening the event dialog (`fbLoading`, `freeBusyRows`, attendee/resource table bodies).
- Show the event dialog before loading attendee free/busy data so a failure in the attendee block does not prevent the form from appearing.
- Normalize attendee JSON with `$A(ev.at)` and isolate attendee loading in a non-fatal `try/catch`.
- **Fix `getAttendeeCell` (and resource row rendering):** do not chain `.classList.add()` before `.insert()` — `classList.add()` returns `undefined` in the browser and caused `TypeError: can't access property "insert", … is undefined`.
- Reset `redBoxLoading` and `fbLoading` in `closeRedBox()` so the event dialog can be reopened after cancel.
- Unstick `redBoxLoading` in `editEvent()` when no RedBox window is open.
- Harden `editEventCallback` for missing calendar config, invalid FB dates, and alarm radio fields outside a form.
- Avoid navigating away when `getEvent` returns no event; log errors to the browser console.

### Attendee JSON (PHP)

- Add `Kronolith_Attendee::getEmailAddress()` to resolve email from identity when only a Horde username is stored.
- Use safe email resolution in `Event::toJson()` for creator response and organizer detection.

### Free/busy for local users (PHP)

- Add `Kronolith_FreeBusy::getUserFromEmail()` to map an email address to a Horde username.
- Use internal free/busy generation (`getForUser`) for local users in both `FreeBusy::get()` and the `getFreeBusy` AJAX action.
- Reduces false warnings such as “No free/busy url found for …” when attendees are Horde users entered by email.

## Files touched

- `vendor/horde/kronolith/lib/Ajax/Application/Handler.php`
- `vendor/horde/kronolith/lib/CalendarsManager.php`
- `vendor/horde/kronolith/lib/FreeBusy.php`
- `vendor/horde/kronolith/lib/Attendee.php`
- `vendor/horde/kronolith/lib/Event.php`
- `vendor/horde/kronolith/js/kronolith.js`

## Test plan

- [ ] Open Kronolith, enable a calendar in the sidebar (eye icon), switch to another Horde app (e.g. IMP), return to Kronolith — calendar stays enabled and events are visible.
- [ ] Disable a calendar, reload Kronolith — calendar stays disabled (no forced default).
- [ ] Create an event with attendees; reopen it from the calendar — event dialog opens with attendee list and free/busy rows.
- [ ] Open an event with attendees, click Cancel, reopen the same event — dialog opens again (no stuck spinner / blocked reopen).
- [ ] Browser console shows no `editEventCallback attendees` error when opening events with attendees.
- [ ] Add a local Horde user as attendee by email — free/busy loads without “no free/busy url found” when the address matches a Horde identity.
- [ ] Toggle remote/resource/holiday calendars if used — preference still persists after navigation.

## Notes

- Vendor patches under `vendor/horde/kronolith/`; upstream Horde contribution may be desirable for long-term maintenance.
- Users who previously hit the double-toggle bug may need to enable their calendar once more so `display_cals` is stored correctly.
