### PR TITLE
fix(kronolith): constrain unsized icons in dynamic event editor

### DIFF
--- a/themes/default/dynamic/screen.css
+++ b/themes/default/dynamic/screen.css
@@ -86,9 +86,11 @@ html, body {
 }
 #kronolithQuickEvent {
     background-image: url("../graphics/new.png");
+    background-size: 16px 16px;
 }
 #kronolithQuickEvent.kronolithNewTask {
     background-image: url("../graphics/new_task.png");
+    background-size: 16px 16px;
 }
 #horde-sidebar div.horde-resources .horde-resource-edit-000,
 #horde-sidebar div.horde-resources .horde-resource-edit-fff {
@@ -355,8 +357,9 @@ ul.horde-tags li:hover {
 #kronolithEventTabResources td.kronolithAttendeeDeclined,
 #kronolithEventTabAttendees td.kronolithAttendeeTentative,
 #kronolithEventTabAttendees td.kronolithAttendeeOrganizer {
-    background-position: 0 0;
+    background-position: 2px center;
     background-repeat: no-repeat;
+    background-size: 16px 16px;
     padding-left: 21px;
 }
 #kronolithEventTabAttendees td.kronolithAttendeeNone,
@@ -387,16 +390,24 @@ ul.horde-tags li:hover {
 }
 #kronolithFBDatePrev, #kronolithResourceFBDatePrev {
     background: transparent url("../graphics/left.png") no-repeat center center;
+    background-size: 16px 16px;
+    box-sizing: content-box;
     cursor: pointer;
     text-indent: -10000px;
     padding: 8px;
+    width: 16px;
+    height: 16px;
     float: left;
 }
 #kronolithFBDateNext, #kronolithResourceFBDateNext {
     background: transparent url("../graphics/right.png") no-repeat center center;
+    background-size: 16px 16px;
+    box-sizing: content-box;
     cursor: pointer;
     padding: 8px;
     text-indent: -10000px;
+    width: 16px;
+    height: 16px;
     float: right;
 }
 #kronolithFBDate {
@@ -728,6 +739,7 @@ tr.kronolithNight td {
 }
 .kronolithAddEvent:hover {
     background-image: url("../graphics/new_small.png");
+    background-size: 15px 15px;
 }
 #kronolithViewIframe iframe {
     position: absolute;

--- a/themes/default/dynamic/screen.css
+++ b/themes/default/dynamic/screen.css
@@ -304,6 +304,20 @@ ul.horde-tags li:hover {
 #kronolithEventACBox, #kronolithTaskACBox, #kronolithCalendarinternalACBox {
     border-top: 0;
 }
+/* Constrain the autocompleter remove icon (delete-small.png) so it cannot
+   render at intrinsic size if the deployed asset is bumped. The widget is
+   shared across Horde apps but the rendered <img> has no size attributes;
+   scope it to Kronolith's AC boxes here rather than wait on horde/base. */
+#kronolithUsersACBox .hordeACItemRemove,
+#kronolithAttendeesACBox .hordeACItemRemove,
+#kronolithResourceACBox .hordeACItemRemove,
+#kronolithEventACBox .hordeACItemRemove,
+#kronolithTaskACBox .hordeACItemRemove,
+#kronolithCalendarinternalACBox .hordeACItemRemove {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+}
 
 #kronolithEventTabAttendees table, #kronolithEventTabResources table {
     border-collapse: collapse;

--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -292,6 +292,23 @@ img.kronolithEventIcon {
     float: left;
     margin: 0 2px 2px 0;
 }
+/* Status and action icons emitted by Event::getLink() and the basic
+   attendees view. The Lucide icon-set bump replaced edit.png and
+   delete.png with 48x48 assets; constrain the rendered <img> so they
+   stay inline-sized in portal blocks and the basic event list. */
+img.iconAlarm,
+img.iconRecur,
+img.iconException,
+img.iconPrivate,
+img.iconPeople,
+img.iconEdit,
+img.iconDelete,
+img.iconAdd,
+img.iconNav {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+}
 .kronolith-event .kronolith-time {
     font-weight: bold;
     margin-right: 2px;


### PR DESCRIPTION
The Lucide icon-set bump (23cbc94b) replaced 16px icons with 48px ones and added background-size to themes/default/screen.css, but did not touch themes/default/dynamic/screen.css. The unsized rules let the new 48px icons paint at intrinsic size, overflowing their containers in the dynamic event editor.

Constrain the affected rules:

- #kronolithQuickEvent / .kronolithNewTask: background-size 16px
- attendee response icons in FB grid (td.kronolithAttendee*): background-size 16px, background-position centered vertically
- FB date prev/next arrows: background-size 16px, explicit 16x16 with box-sizing: content-box so existing 8px padding stays additive
- .kronolithAddEvent:hover: background-size 15px to match the 15x15 parent box

Fixes #51