### PR TITLE
feat(kronolith): store and sync EAS 16.1 attendee proposals and disal…

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -1370,10 +1370,12 @@ class Kronolith_Api extends Horde_Registry_Api
      *                                          update. Attendees are only
      *                                          updated if this address
      *                                          matches.
+     * @param boolean $storeProposal            Store proposed meeting times
+     *                                          from a METHOD=COUNTER message.
      *
      * @throws Kronolith_Exception
      */
-    public function updateAttendee($response, $sender = null)
+    public function updateAttendee($response, $sender = null, $storeProposal = false)
     {
         try {
             $uid = $response->getAttribute('UID');
@@ -1440,6 +1442,9 @@ class Kronolith_Api extends Horde_Registry_Api
                         Kronolith::responseFromICal($partstat),
                         $name
                     );
+                    if ($storeProposal) {
+                        $this->_storeAttendeeProposal($event, $attendee, $response);
+                    }
                     $found = true;
                 } else {
                     $error = _("The attendee hasn't been updated because the update was not sent from the attendee.");
@@ -1450,6 +1455,35 @@ class Kronolith_Api extends Horde_Registry_Api
 
         if (!$found) {
             throw new Kronolith_Exception($error);
+        }
+    }
+
+    /**
+     * Store proposed meeting times from a counter-proposal on an attendee.
+     */
+    protected function _storeAttendeeProposal(
+        Kronolith_Event $event,
+        $attendeeEmail,
+        Horde_Icalendar_Vevent $response
+    ) {
+        try {
+            $proposedStart = new Horde_Date($response->getAttribute('DTSTART'));
+        } catch (Horde_Icalendar_Exception $e) {
+            return;
+        }
+
+        $proposedEnd = null;
+        try {
+            $proposedEnd = new Horde_Date($response->getAttribute('DTEND'));
+        } catch (Horde_Icalendar_Exception $e) {
+        }
+
+        foreach ($event->attendees as $attendee) {
+            if ($attendee->matchesEmail($attendeeEmail, false)) {
+                $attendee->proposedStart = $proposedStart;
+                $attendee->proposedEnd = $proposedEnd;
+                break;
+            }
         }
     }
 

--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -224,8 +224,8 @@ class Kronolith_Attendee implements Serializable
             'name' => $this->name,
             'role' => $this->role,
             'response' => $this->response,
-            'proposedStart' => $this->proposedStart,
-            'proposedEnd' => $this->proposedEnd,
+            'proposedStart' => $this->_proposedDateToHash($this->proposedStart),
+            'proposedEnd' => $this->_proposedDateToHash($this->proposedEnd),
         ];
     }
 
@@ -284,15 +284,24 @@ class Kronolith_Attendee implements Serializable
 
     public function __serialize(): array
     {
-        return [
+        $data = [
             'u' => $this->user,
             'e' => $this->email,
             'p' => $this->role,
             'r' => $this->response,
             'n' => $this->name,
-            'ps' => $this->proposedStart ? $this->proposedStart->timestamp() : null,
-            'pe' => $this->proposedEnd ? $this->proposedEnd->timestamp() : null,
         ];
+
+        if ($this->proposedStart) {
+            $data['ps'] = $this->proposedStart->toJson();
+            $data['pstz'] = $this->proposedStart->timezone;
+        }
+        if ($this->proposedEnd) {
+            $data['pe'] = $this->proposedEnd->toJson();
+            $data['petz'] = $this->proposedEnd->timezone;
+        }
+
+        return $data;
     }
 
     /**
@@ -311,11 +320,43 @@ class Kronolith_Attendee implements Serializable
         $this->role     = $data['p'];
         $this->response = $data['r'];
         $this->name     = $data['n'];
-        $this->proposedStart = !empty($data['ps'] ?? null)
-            ? new Horde_Date($data['ps'])
-            : null;
-        $this->proposedEnd = !empty($data['pe'] ?? null)
-            ? new Horde_Date($data['pe'])
-            : null;
+        $this->proposedStart = $this->_proposedDateFromStorage(
+            $data['ps'] ?? null,
+            $data['pstz'] ?? null
+        );
+        $this->proposedEnd = $this->_proposedDateFromStorage(
+            $data['pe'] ?? null,
+            $data['petz'] ?? null
+        );
+    }
+
+    /**
+     * Export a proposed meeting time for backup/API transport.
+     *
+     * @return array{date: string, time: string, timezone: string}|null
+     */
+    protected function _proposedDateToHash(?Horde_Date $date): ?array
+    {
+        if (!$date) {
+            return null;
+        }
+
+        return [
+            'date' => $date->format('Y-m-d'),
+            'time' => $date->format('H:i:s'),
+            'timezone' => $date->timezone,
+        ];
+    }
+
+    /**
+     * Restore a proposed meeting time from persisted attendee data.
+     */
+    protected function _proposedDateFromStorage($value, $timezone): ?Horde_Date
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return new Horde_Date($value, $timezone ?: null);
     }
 }

--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -314,7 +314,7 @@ class Kronolith_Attendee implements Serializable
         $this->proposedStart = !empty($data['ps'] ?? null)
             ? new Horde_Date($data['ps'])
             : null;
-        $this->proposedEnd = !empty($data['pe'])
+        $this->proposedEnd = !empty($data['pe'] ?? null)
             ? new Horde_Date($data['pe'])
             : null;
     }

--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -311,7 +311,7 @@ class Kronolith_Attendee implements Serializable
         $this->role     = $data['p'];
         $this->response = $data['r'];
         $this->name     = $data['n'];
-        $this->proposedStart = !empty($data['ps'])
+        $this->proposedStart = !empty($data['ps'] ?? null)
             ? new Horde_Date($data['ps'])
             : null;
         $this->proposedEnd = !empty($data['pe'])

--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -290,8 +290,8 @@ class Kronolith_Attendee implements Serializable
             'p' => $this->role,
             'r' => $this->response,
             'n' => $this->name,
-            'ps' => $this->proposedStart ? $this->proposedStart->timestamp : null,
-            'pe' => $this->proposedEnd ? $this->proposedEnd->timestamp : null,
+            'ps' => $this->proposedStart ? $this->proposedStart->timestamp() : null,
+            'pe' => $this->proposedEnd ? $this->proposedEnd->timestamp() : null,
         ];
     }
 

--- a/lib/Attendee.php
+++ b/lib/Attendee.php
@@ -64,6 +64,20 @@ class Kronolith_Attendee implements Serializable
     public $response;
 
     /**
+     * Proposed meeting start time from a counter-proposal.
+     *
+     * @var Horde_Date|null
+     */
+    public $proposedStart;
+
+    /**
+     * Proposed meeting end time from a counter-proposal.
+     *
+     * @var Horde_Date|null
+     */
+    public $proposedEnd;
+
+    /**
      * Constructor.
      *
      * @param array $params  Attendee properties:
@@ -89,6 +103,8 @@ class Kronolith_Attendee implements Serializable
                 'role'     => Kronolith::PART_REQUIRED,
                 'response' => Kronolith::RESPONSE_NONE,
                 'name'     => null,
+                'proposedStart' => null,
+                'proposedEnd' => null,
             ],
             $params
         );
@@ -97,6 +113,8 @@ class Kronolith_Attendee implements Serializable
         $this->name     = $params['name'];
         $this->role     = $params['role'];
         $this->response = $params['response'];
+        $this->proposedStart = $params['proposedStart'];
+        $this->proposedEnd = $params['proposedEnd'];
 
         if (isset($this->user)
             && isset($params['identities'])
@@ -206,6 +224,8 @@ class Kronolith_Attendee implements Serializable
             'name' => $this->name,
             'role' => $this->role,
             'response' => $this->response,
+            'proposedStart' => $this->proposedStart,
+            'proposedEnd' => $this->proposedEnd,
         ];
     }
 
@@ -270,6 +290,8 @@ class Kronolith_Attendee implements Serializable
             'p' => $this->role,
             'r' => $this->response,
             'n' => $this->name,
+            'ps' => $this->proposedStart ? $this->proposedStart->timestamp : null,
+            'pe' => $this->proposedEnd ? $this->proposedEnd->timestamp : null,
         ];
     }
 
@@ -289,5 +311,11 @@ class Kronolith_Attendee implements Serializable
         $this->role     = $data['p'];
         $this->response = $data['r'];
         $this->name     = $data['n'];
+        $this->proposedStart = !empty($data['ps'])
+            ? new Horde_Date($data['ps'])
+            : null;
+        $this->proposedEnd = !empty($data['pe'])
+            ? new Horde_Date($data['pe'])
+            : null;
     }
 }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -426,6 +426,12 @@ abstract class Kronolith_Event
      */
     public const EAS_CLIENTUID_ATTRIBUTE = 'X-HORDE-EAS-CLIENTUID';
 
+    protected const DISALLOW_COUNTER_ATTRIBUTES = [
+        'DISALLOW-COUNTER',
+        'X-MICROSOFT-DISALLOW-COUNTER',
+        'X-MS-DISALLOW-COUNTER',
+    ];
+
     protected array $knownAttributes = [
         'ATTACH',
         'ATTENDEE',
@@ -1781,6 +1787,52 @@ abstract class Kronolith_Event
     }
 
     /**
+     * Whether this event forbids attendees from proposing new meeting times.
+     */
+    protected function _disallowsNewTimeProposal(): bool
+    {
+        foreach ($this->otherAttributes as $attribute) {
+            $name = strtoupper((string) ($attribute['name'] ?? ''));
+            if (!in_array($name, self::DISALLOW_COUNTER_ATTRIBUTES, true)) {
+                continue;
+            }
+            $value = $attribute['value'] ?? '';
+            if (is_array($value)) {
+                $value = reset($value);
+            }
+            if (is_string($value)
+                && in_array(strtoupper(trim($value)), ['1', 'TRUE', 'YES'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Store or clear iCal disallow-counter state for proposal restrictions.
+     */
+    protected function _setDisallowCounter(bool $disallow): void
+    {
+        $this->otherAttributes = array_values(array_filter(
+            $this->otherAttributes,
+            function ($attribute) {
+                $name = strtoupper((string) ($attribute['name'] ?? ''));
+                return !in_array($name, self::DISALLOW_COUNTER_ATTRIBUTES, true);
+            }
+        ));
+
+        if ($disallow) {
+            $this->otherAttributes[] = [
+                'name' => 'DISALLOW-COUNTER',
+                'value' => 'TRUE',
+                'params' => [],
+                'values' => null,
+            ];
+        }
+    }
+
+    /**
      * Import an EAS 16 AirSyncBase:Location object into event fields.
      */
     protected function _importEasLocation($location): void
@@ -2025,6 +2077,11 @@ abstract class Kronolith_Event
         /* Sensitivity */
         if (!$message->isGhosted('sensitivity')) {
             $this->private = ($message->getSensitivity() == Horde_ActiveSync_Message_Appointment::SENSITIVITY_PRIVATE || $message->getSensitivity() == Horde_ActiveSync_Message_Appointment::SENSITIVITY_CONFIDENTIAL) ? true : false;
+        }
+
+        if ($version >= Horde_ActiveSync::VERSION_FOURTEEN
+            && !$message->isGhosted('disallownewtimeproposal')) {
+            $this->_setDisallowCounter(!empty($message->getProperty('disallownewtimeproposal')));
         }
 
         /* Busy Status */
@@ -2407,6 +2464,11 @@ abstract class Kronolith_Event
             ? Horde_ActiveSync_Message_Appointment::SENSITIVITY_PRIVATE
             : Horde_ActiveSync_Message_Appointment::SENSITIVITY_NORMAL);
 
+        if ($options['protocolversion'] >= Horde_ActiveSync::VERSION_FOURTEEN
+            && $this->_disallowsNewTimeProposal()) {
+            $message->disallownewtimeproposal = true;
+        }
+
         // Busy Status
         // This is the *busy* status of the time for this meeting. This is NOT
         // the Kronolith_Event::status or the attendance response for this
@@ -2571,6 +2633,15 @@ abstract class Kronolith_Event
                             break;
                         default:
                             $attendeeAS->status = Horde_ActiveSync_Message_Attendee::STATUS_UNKNOWN;
+                    }
+                }
+
+                if ($options['protocolversion'] >= Horde_ActiveSync::VERSION_SIXTEENONE) {
+                    if (!empty($attendee->proposedStart)) {
+                        $attendeeAS->proposedstarttime = clone $attendee->proposedStart;
+                    }
+                    if (!empty($attendee->proposedEnd)) {
+                        $attendeeAS->proposedendtime = clone $attendee->proposedEnd;
                     }
                 }
 

--- a/test/Kronolith/Unit/AttendeeTest.php
+++ b/test/Kronolith/Unit/AttendeeTest.php
@@ -213,6 +213,46 @@ class Kronolith_Unit_AttendeeTest extends Horde_Test_Case
         return $serialized;
     }
 
+    public function testSerializeProposedTimesPreservesTimezone()
+    {
+        $attendee = new Kronolith_Attendee([
+            'email' => 'alice@example.com',
+            'proposedStart' => new Horde_Date('2026-06-17T14:00:00', 'Europe/Berlin'),
+            'proposedEnd' => new Horde_Date('2026-06-17T15:00:00', 'Europe/Berlin'),
+        ]);
+
+        $restored = unserialize(serialize($attendee));
+
+        $this->assertInstanceOf('Horde_Date', $restored->proposedStart);
+        $this->assertInstanceOf('Horde_Date', $restored->proposedEnd);
+        $this->assertSame('Europe/Berlin', $restored->proposedStart->timezone);
+        $this->assertSame('Europe/Berlin', $restored->proposedEnd->timezone);
+        $this->assertSame(
+            $attendee->proposedStart->timestamp(),
+            $restored->proposedStart->timestamp()
+        );
+        $this->assertSame(
+            $attendee->proposedEnd->timestamp(),
+            $restored->proposedEnd->timestamp()
+        );
+    }
+
+    public function testToHashExportsScalarProposedTimes()
+    {
+        $attendee = new Kronolith_Attendee([
+            'email' => 'alice@example.com',
+            'proposedStart' => new Horde_Date('2026-06-17T14:00:00', 'UTC'),
+        ]);
+
+        $hash = $attendee->toHash();
+
+        $this->assertIsArray($hash['proposedStart']);
+        $this->assertSame('2026-06-17', $hash['proposedStart']['date']);
+        $this->assertSame('14:00:00', $hash['proposedStart']['time']);
+        $this->assertSame('UTC', $hash['proposedStart']['timezone']);
+        $this->assertNull($hash['proposedEnd']);
+    }
+
     /**
      * @depends testSerialize
      */

--- a/test/Kronolith/Unit/EventActiveSyncTest.php
+++ b/test/Kronolith/Unit/EventActiveSyncTest.php
@@ -207,4 +207,56 @@ class Kronolith_Unit_EventActiveSyncTest extends TestCase
         $this->assertSame('52.5200', $exported->location->latitude);
         $this->assertSame('13.4050', $exported->location->longitude);
     }
+
+    public function testToASAppointmentExportsAttendeeProposedTimesForEas161()
+    {
+        $event = $this->_createEvent();
+        $event->status = Kronolith::STATUS_CONFIRMED;
+        $event->attendees->add(new Kronolith_Attendee([
+            'email' => 'guest@example.com',
+            'name' => 'Guest',
+            'response' => Kronolith::RESPONSE_TENTATIVE,
+            'proposedStart' => new Horde_Date('2026-06-17T14:00:00', 'UTC'),
+            'proposedEnd' => new Horde_Date('2026-06-17T15:00:00', 'UTC'),
+        ]));
+
+        $message = $event->toASAppointment([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEENONE,
+        ]);
+
+        $attendees = $message->getAttendees();
+        $this->assertCount(1, $attendees);
+        $this->assertInstanceOf('Horde_Date', $attendees[0]->proposedstarttime);
+        $this->assertInstanceOf('Horde_Date', $attendees[0]->proposedendtime);
+        $this->assertSame(
+            '20260617T140000Z',
+            $attendees[0]->proposedstarttime->format('Ymd\THis\Z')
+        );
+        $this->assertSame(
+            '20260617T150000Z',
+            $attendees[0]->proposedendtime->format('Ymd\THis\Z')
+        );
+    }
+
+    public function testDisallowNewTimeProposalRoundTrip()
+    {
+        $event = $this->_createEvent();
+        $message = $this->_createAppointment();
+        $message->disallownewtimeproposal = true;
+        $message->subject = 'No proposals';
+        $message->starttime = new Horde_Date('2026-06-16T10:00:00', 'UTC');
+        $message->endtime = new Horde_Date('2026-06-16T11:00:00', 'UTC');
+
+        $event->fromASAppointment($message);
+
+        $exported = $event->toASAppointment([
+            'protocolversion' => Horde_ActiveSync::VERSION_FOURTEEN,
+        ]);
+        $this->assertTrue($exported->disallownewtimeproposal);
+
+        $legacy = $event->toASAppointment([
+            'protocolversion' => Horde_ActiveSync::VERSION_TWELVEONE,
+        ]);
+        $this->assertEmpty($legacy->disallownewtimeproposal);
+    }
 }


### PR DESCRIPTION
# feat(kronolith): store and sync EAS 16.1 attendee proposals

## Summary

Persists attendee **proposed meeting times** from iTip COUNTER / ActiveSync sync and exports them back to EAS ≥16.1 clients. Also adds **`DisallowNewTimeProposal`** round-trip via calendar events and fixes a PHP warning in event history diffing during device calendar updates.

## Motivation

EAS 16.1 syncs `ProposedStartTime` / `ProposedEndTime` on attendees. Kronolith must store proposals on attendee records, export them in `toASAppointment()`, and honour organizer “no new time proposals” policy via `DisallowNewTimeProposal` (mapped from iCal disallow-counter attributes).

## Changes

### Attendee proposal storage

- `Kronolith_Attendee` — `proposedStart` / `proposedEnd` properties; serialize as `ps` / `pe` in attendee blobs.
- `Kronolith_Api::updateAttendee()` — optional `$storeProposal` flag stores `DTSTART`/`DTEND` from incoming COUNTER on the matching attendee.

### ActiveSync import/export

- `Kronolith_Event::toASAppointment()` — for protocol ≥16.1, set attendee `proposedstarttime` / `proposedendtime` on AS message.
- `fromASAppointment()` — import `disallownewtimeproposal` when present.
- `_disallowsNewTimeProposal()` — reads `DISALLOW-COUNTER` and Microsoft variants from event attributes.
- `toASAppointment()` — export `disallownewtimeproposal` when EAS ≥14.0 and event disallows proposals.

### Bug fix

- `Kronolith_Driver_Sql::_buildEventHistory()` — use null coalescing for missing `oldProperties` keys (fixes undefined array key warnings when recurring exceptions are updated from ActiveSync).

### Tests

- `test/Kronolith/Unit/EventActiveSyncTest.php` — proposed times export on 16.1; `DisallowNewTimeProposal` round-trip; legacy protocol omits flag.

## Files changed

```
lib/Attendee.php
lib/Api.php
lib/Event.php
lib/Driver/Sql.php
test/Kronolith/Unit/EventActiveSyncTest.php
```

## Dependencies

- **activesync** — `VERSION_SIXTEENONE`, attendee proposed-time message properties, `disallownewtimeproposal` on appointments.
- Merge **before** `horde/imp` (organizer counter-accept calls `calendar/updateAttendee` with `$storeProposal`).

## Test plan

- [ ] `vendor/bin/phpunit test/Kronolith/Unit/EventActiveSyncTest.php`
- [ ] Update recurring exception from ActiveSync — no PHP warnings in `horde.log` from `_buildEventHistory`.
- [ ] Manual: organizer sees attendee proposal times after device sync (16.1); `DisallowNewTimeProposal` set on device blocks proposals (with core PR).

## Suggested commit messages

Primary feature:

```
feat(kronolith): store and sync EAS 16.1 attendee proposals

Persist proposed start/end on attendees, export on AS 16.1+, and
round-trip DisallowNewTimeProposal from iCal disallow-counter flags.
```

Optional separate fix commit:

```
fix(kronolith): avoid undefined keys in event history diff

Use null coalescing when old event properties lack recurrence keys.
```
