### PR TITLE
feat(kronolith): EAS 16.1 counter-proposals and proposal clear on sync

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -966,7 +966,12 @@ class Kronolith_Api extends Horde_Registry_Api
                 return $iCal->exportvCalendar();
 
             case 'activesync':
-                return $event->toASAppointment($options);
+                $message = $event->toASAppointment($options);
+                if ($event->needsEasProposalClear() && $event->hasPermission(Horde_Perms::EDIT)) {
+                    $event->setEasProposalClear(false);
+                    $event->save();
+                }
+                return $message;
         }
 
         throw new Kronolith_Exception(sprintf(_("Unsupported Content-Type: %s"), $contentType));
@@ -1285,12 +1290,32 @@ class Kronolith_Api extends Horde_Registry_Api
             $component->getAttribute('RECURRENCE-ID');
             $this->_addiCalEvent($component, Kronolith::getDriver(null, $calendar), true);
         } catch (Horde_Icalendar_Exception $e) {
+            $hadProposal = $this->_authAttendeeHasProposal($event);
             $event->fromiCalendar($component, true);
             // Ensure we keep the original UID, even when content does not
             // contain one and fromiCalendar creates a new one.
             $event->uid = $uid;
+            if ($hadProposal && !$this->_authAttendeeHasProposal($event)) {
+                $event->setEasProposalClear(true);
+            }
             $event->save();
         }
+    }
+
+    /**
+     * Whether the authenticated user has stored proposal times on this event.
+     */
+    protected function _authAttendeeHasProposal(Kronolith_Event $event): bool
+    {
+        $auth = $GLOBALS['registry']->getAuth();
+        foreach ($event->attendees as $attendee) {
+            if (Kronolith::isUserEmail($auth, $attendee->email)
+                || ($attendee->user && $attendee->user == $auth)) {
+                return !empty($attendee->proposedStart) || !empty($attendee->proposedEnd);
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -1383,33 +1408,7 @@ class Kronolith_Api extends Horde_Registry_Api
             throw new Kronolith_Exception($e);
         }
 
-        $events = Kronolith::getDriver()->getByUID($uid, null, true);
-
-        /* First try the user's own calendars. */
-        $ownerCalendars = Kronolith::listInternalCalendars(true, Horde_Perms::EDIT);
-        $event = null;
-        foreach ($events as $ev) {
-            if (isset($ownerCalendars[$ev->calendar])) {
-                $event = $ev;
-                break;
-            }
-        }
-
-        /* If not successful, try all calendars the user has access to. */
-        if (empty($event)) {
-            $editableCalendars = Kronolith::listInternalCalendars(false, Horde_Perms::EDIT);
-            foreach ($events as $ev) {
-                if (isset($editableCalendars[$ev->calendar])) {
-                    $event = $ev;
-                    break;
-                }
-            }
-        }
-
-        if (empty($event)
-            || ($event->private && $event->creator != $GLOBALS['registry']->getAuth())) {
-            throw new Horde_Exception_PermissionDenied();
-        }
+        $event = $this->_getEditableEventByUid($uid);
 
         $atnames = $response->getAttribute('ATTENDEE');
         if (!is_array($atnames)) {
@@ -1456,6 +1455,208 @@ class Kronolith_Api extends Horde_Registry_Api
         if (!$found) {
             throw new Kronolith_Exception($error);
         }
+    }
+
+    /**
+     * Finalize an accepted counter-proposal on the organizer's event.
+     *
+     * Clears stored proposal metadata for the proposing attendee and sends
+     * METHOD=REQUEST iTip updates so attendees receive the new event times.
+     *
+     * @param Horde_Icalendar_Vevent $response  The METHOD=COUNTER vEvent.
+     * @param string $sender                    Email of the proposing attendee.
+     *
+     * @throws Kronolith_Exception
+     */
+    public function acceptCounterProposal(Horde_Icalendar_Vevent $response, $sender)
+    {
+        try {
+            $uid = $response->getAttribute('UID');
+        } catch (Horde_Icalendar_Exception $e) {
+            throw new Kronolith_Exception($e);
+        }
+
+        $event = $this->_getEditableEventByUid($uid);
+
+        $found = false;
+        foreach ($event->attendees as $attendee) {
+            if ($attendee->matchesEmail($sender, false)) {
+                $attendee->proposedStart = null;
+                $attendee->proposedEnd = null;
+                $found = true;
+                break;
+            }
+        }
+
+        if (!$found) {
+            throw new Kronolith_Exception(
+                _("No attendees have been updated because none of the provided email addresses have been found in the event's attendees list.")
+            );
+        }
+
+        $event->sequence = ($event->sequence ?? 0) + 1;
+        $event->save();
+
+        // Only the organizer's copy should trigger REQUEST updates to attendees.
+        if (empty($event->organizer)
+            || Kronolith::isUserEmail($event->creator, $event->organizer)) {
+            Kronolith::sendITipNotifications(
+                $event,
+                $GLOBALS['notification'],
+                Kronolith::ITIP_REQUEST
+            );
+        }
+    }
+
+    /**
+     * Clear a stored counter-proposal for an attendee.
+     *
+     * On the organizer's calendar, pass the proposing attendee's email and
+     * set $notifyAttendee to send a METHOD=REQUEST update. On an attendee's
+     * calendar, omit $attendeeEmail to clear the current user's proposal.
+     *
+     * @param Horde_Icalendar_Vevent $response  Related vEvent (UID required).
+     * @param string|null $attendeeEmail         Proposing attendee, or null for
+     *                                           the current user.
+     * @param boolean $notifyAttendee            Send REQUEST to the attendee.
+     *
+     * @throws Kronolith_Exception
+     */
+    public function declineCounterProposal(
+        Horde_Icalendar_Vevent $response,
+        $attendeeEmail = null,
+        $notifyAttendee = false
+    ) {
+        try {
+            $uid = $response->getAttribute('UID');
+        } catch (Horde_Icalendar_Exception $e) {
+            throw new Kronolith_Exception($e);
+        }
+
+        $event = $this->_getEditableEventByUid($uid);
+        $found = false;
+        $targetEmail = $attendeeEmail;
+
+        if ($attendeeEmail === null) {
+            $auth = $GLOBALS['registry']->getAuth();
+            foreach ($event->attendees as $attendee) {
+                if (Kronolith::isUserEmail($auth, $attendee->email)
+                    || ($attendee->user && $attendee->user == $auth)) {
+                    $attendee->proposedStart = null;
+                    $attendee->proposedEnd = null;
+                    $targetEmail = $attendee->email;
+                    $found = true;
+                    break;
+                }
+            }
+        } else {
+            foreach ($event->attendees as $attendee) {
+                if ($attendee->matchesEmail($attendeeEmail, false)) {
+                    $attendee->proposedStart = null;
+                    $attendee->proposedEnd = null;
+                    $found = true;
+                    break;
+                }
+            }
+        }
+
+        if (!$found) {
+            throw new Kronolith_Exception(
+                _("No attendees have been updated because none of the provided email addresses have been found in the event's attendees list.")
+            );
+        }
+
+        $event->sequence = ($event->sequence ?? 0) + 1;
+        if ($attendeeEmail === null) {
+            $event->setEasProposalClear(true);
+        }
+        $event->save();
+
+        if ($notifyAttendee
+            && (empty($event->organizer)
+                || Kronolith::isUserEmail($event->creator, $event->organizer))) {
+            $recipients = new Kronolith_Attendee_List();
+            foreach ($event->attendees as $attendee) {
+                if ($attendee->matchesEmail($targetEmail, false)) {
+                    $recipients->add($attendee);
+                    break;
+                }
+            }
+            if (count($recipients)) {
+                Kronolith::sendITipNotifications(
+                    $event,
+                    $GLOBALS['notification'],
+                    Kronolith::ITIP_REQUEST,
+                    null,
+                    null,
+                    null,
+                    $recipients
+                );
+            }
+        }
+    }
+
+    /**
+     * Store proposed meeting times on an attendee record.
+     *
+     * @throws Kronolith_Exception
+     */
+    public function storeAttendeeProposal(
+        $uid,
+        $attendeeEmail,
+        Horde_Date $proposedStart,
+        Horde_Date $proposedEnd = null
+    ) {
+        $event = $this->_getEditableEventByUid($uid);
+
+        foreach ($event->attendees as $attendee) {
+            if ($attendee->matchesEmail($attendeeEmail, false)) {
+                $attendee->proposedStart = $proposedStart;
+                $attendee->proposedEnd = $proposedEnd;
+                $event->save();
+                return;
+            }
+        }
+
+        throw new Kronolith_Exception(
+            _("No attendees have been updated because none of the provided email addresses have been found in the event's attendees list.")
+        );
+    }
+
+    /**
+     * Returns an editable event in the current user's calendars by UID.
+     *
+     * @throws Horde_Exception_PermissionDenied
+     */
+    protected function _getEditableEventByUid($uid)
+    {
+        $events = Kronolith::getDriver()->getByUID($uid, null, true);
+
+        $ownerCalendars = Kronolith::listInternalCalendars(true, Horde_Perms::EDIT);
+        $event = null;
+        foreach ($events as $ev) {
+            if (isset($ownerCalendars[$ev->calendar])) {
+                $event = $ev;
+                break;
+            }
+        }
+
+        if (empty($event)) {
+            $editableCalendars = Kronolith::listInternalCalendars(false, Horde_Perms::EDIT);
+            foreach ($events as $ev) {
+                if (isset($editableCalendars[$ev->calendar])) {
+                    $event = $ev;
+                    break;
+                }
+            }
+        }
+
+        if (empty($event)
+            || ($event->private && $event->creator != $GLOBALS['registry']->getAuth())) {
+            throw new Horde_Exception_PermissionDenied();
+        }
+
+        return $event;
     }
 
     /**

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -967,7 +967,14 @@ class Kronolith_Api extends Horde_Registry_Api
 
             case 'activesync':
                 $message = $event->toASAppointment($options);
-                if ($event->needsEasProposalClear() && $event->hasPermission(Horde_Perms::EDIT)) {
+                $emittedClear = false;
+                foreach ($message->getAttendees() as $attendeeAS) {
+                    if (!empty($attendeeAS->clearProposedTimes)) {
+                        $emittedClear = true;
+                        break;
+                    }
+                }
+                if ($emittedClear && $event->hasPermission(Horde_Perms::EDIT)) {
                     $event->setEasProposalClear(false);
                     $event->save();
                 }

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -426,6 +426,8 @@ abstract class Kronolith_Event
      */
     public const EAS_CLIENTUID_ATTRIBUTE = 'X-HORDE-EAS-CLIENTUID';
 
+    public const EAS_PROPOSAL_CLEAR_ATTRIBUTE = 'X-HORDE-EAS-PROPOSAL-CLEAR';
+
     protected const DISALLOW_COUNTER_ATTRIBUTES = [
         'DISALLOW-COUNTER',
         'X-MICROSOFT-DISALLOW-COUNTER',
@@ -1787,6 +1789,43 @@ abstract class Kronolith_Event
     }
 
     /**
+     * Whether the next ActiveSync export should clear proposed meeting times
+     * on the current user's attendee record.
+     */
+    public function needsEasProposalClear(): bool
+    {
+        foreach ($this->otherAttributes as $attribute) {
+            if (($attribute['name'] ?? null) === self::EAS_PROPOSAL_CLEAR_ATTRIBUTE) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Queue or clear an ActiveSync proposal reset for the current user.
+     */
+    public function setEasProposalClear(bool $pending): void
+    {
+        $this->otherAttributes = array_values(array_filter(
+            $this->otherAttributes,
+            function ($attribute) {
+                return ($attribute['name'] ?? null) !== self::EAS_PROPOSAL_CLEAR_ATTRIBUTE;
+            }
+        ));
+
+        if ($pending) {
+            $this->otherAttributes[] = [
+                'name' => self::EAS_PROPOSAL_CLEAR_ATTRIBUTE,
+                'value' => '1',
+                'params' => [],
+                'values' => null,
+            ];
+        }
+    }
+
+    /**
      * Whether this event forbids attendees from proposing new meeting times.
      */
     protected function _disallowsNewTimeProposal(): bool
@@ -2637,11 +2676,17 @@ abstract class Kronolith_Event
                 }
 
                 if ($options['protocolversion'] >= Horde_ActiveSync::VERSION_SIXTEENONE) {
-                    if (!empty($attendee->proposedStart)) {
-                        $attendeeAS->proposedstarttime = clone $attendee->proposedStart;
-                    }
-                    if (!empty($attendee->proposedEnd)) {
-                        $attendeeAS->proposedendtime = clone $attendee->proposedEnd;
+                    $clearProposals = $this->needsEasProposalClear()
+                        && Kronolith::isUserEmail($registry->getAuth(), $attendee->email);
+                    if (!$clearProposals) {
+                        if (!empty($attendee->proposedStart)) {
+                            $attendeeAS->proposedstarttime = clone $attendee->proposedStart;
+                        }
+                        if (!empty($attendee->proposedEnd)) {
+                            $attendeeAS->proposedendtime = clone $attendee->proposedEnd;
+                        }
+                    } else {
+                        $attendeeAS->clearProposedTimes = true;
                     }
                 }
 

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -2676,8 +2676,10 @@ abstract class Kronolith_Event
                 }
 
                 if ($options['protocolversion'] >= Horde_ActiveSync::VERSION_SIXTEENONE) {
+                    $auth = $registry->getAuth();
                     $clearProposals = $this->needsEasProposalClear()
-                        && Kronolith::isUserEmail($registry->getAuth(), $attendee->email);
+                        && (Kronolith::isUserEmail($auth, $attendee->email)
+                            || ($attendee->user && $attendee->user == $auth));
                     if (!$clearProposals) {
                         if (!empty($attendee->proposedStart)) {
                             $attendeeAS->proposedstarttime = clone $attendee->proposedStart;

--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -904,6 +904,7 @@ class Kronolith
         } else {
             return new Kronolith_Attendee([
                 'user' => $user,
+                'email' => self::getUserEmail($user),
                 'identities' => $injector->getInstance('Horde_Core_Factory_Identity'),
             ]);
         }
@@ -2410,6 +2411,9 @@ class Kronolith
      *                                                are the ONLY people that
      *                                                will receive the CANCEL
      *                                                iTIP.  @since 4.2.10
+     * @param Kronolith_Attendee_List $limitedAttendees  If set, only these
+     *                                                attendees receive the
+     *                                                notification.
      */
     public static function sendITipNotifications(
         Kronolith_Event $event,
@@ -2417,11 +2421,12 @@ class Kronolith
         $action,
         ?Horde_Date $instance = null,
         $range = null,
-        ?Kronolith_Attendee_List $cancellations = null
+        ?Kronolith_Attendee_List $cancellations = null,
+        ?Kronolith_Attendee_List $limitedAttendees = null
     ) {
         global $injector, $prefs, $registry;
 
-        if (!count($event->attendees) || $prefs->getValue('itip_silent')) {
+        if (!$event->attendees || !count($event->attendees) || $prefs->getValue('itip_silent')) {
             return;
         }
 
@@ -2442,7 +2447,9 @@ class Kronolith
         $view->event = clone $event;
         $view->imageId = $image->getContentId();
 
-        if ($action == self::ITIP_CANCEL && $cancellations !== null && count($cancellations)) {
+        if ($limitedAttendees !== null && count($limitedAttendees)) {
+            $mail_attendees = $limitedAttendees;
+        } elseif ($action == self::ITIP_CANCEL && $cancellations !== null && count($cancellations)) {
             $mail_attendees = $cancellations;
         } elseif ($event->organizer
                   && !self::isUserEmail($event->creator, $event->organizer)) {
@@ -2458,18 +2465,39 @@ class Kronolith
             $mail_attendees = $event->attendees;
         }
 
+        if ($action == self::ITIP_REQUEST) {
+            $proposalUpdated = false;
+            foreach ($event->attendees as $attendee) {
+                if (!empty($attendee->proposedStart) || !empty($attendee->proposedEnd)) {
+                    $attendee->proposedStart = null;
+                    $attendee->proposedEnd = null;
+                    $proposalUpdated = true;
+                }
+            }
+            if ($proposalUpdated) {
+                $event->save();
+            }
+        }
+
         foreach ($mail_attendees as $attendee) {
+            $recipientEmail = $attendee->email;
+            if ((!$recipientEmail || strpos($recipientEmail, '@') === false) && $attendee->user) {
+                $recipientEmail = self::getUserEmail($attendee->user);
+            }
+
             /* Don't send notifications to the ORGANIZER if this is the
              * ORGANIZER's copy of the event. */
             if (!$event->organizer
-                && Kronolith::isUserEmail($event->creator, $attendee->email)) {
+                && (self::isUserEmail($event->creator, $recipientEmail)
+                    || ($attendee->user
+                        && self::isUserEmail($event->creator, $attendee->user)))) {
                 continue;
             }
 
             /* Don't bother sending an invitation/update if the recipient does
              * not need to participate, or has declined participating, or
              * doesn't have an email address. */
-            if (strpos($attendee->email, '@') === false
+            if (strpos($recipientEmail, '@') === false
                 || $attendee->response == self::RESPONSE_DECLINED) {
                 continue;
             }
@@ -2596,6 +2624,18 @@ class Kronolith
             }
             $iCal->addComponent($vevent);
 
+            if ($action == self::ITIP_REQUEST) {
+                $requestEvent = is_array($vevent) ? reset($vevent) : $vevent;
+                if ($requestEvent instanceof Horde_Icalendar_Vevent) {
+                    self::_applyItipRequestToLocalUser(
+                        $attendee,
+                        $recipientEmail,
+                        $event->uid,
+                        $requestEvent
+                    );
+                }
+            }
+
             $icsData = $iCal->exportvCalendar();
 
             /* Inline text/calendar for IMP/Outlook (iTip UI). */
@@ -2623,7 +2663,10 @@ class Kronolith
             $multipart->addPart($inner);
             $multipart->addPart($ics);
 
-            $recipient = $attendee->addressObject;
+            $recipient = new Horde_Mail_Rfc822_Address($recipientEmail);
+            if (!empty($attendee->name)) {
+                $recipient->personal = $attendee->name;
+            }
             $mail = new Horde_Mime_Mail(
                 ['Subject' => $view->subject,
                     'To' => $recipient,
@@ -2645,6 +2688,133 @@ class Kronolith
                 );
             }
         }
+    }
+
+    /**
+     * Clear a counter-proposal on a local attendee calendar (server-side).
+     *
+     * Used when the organizer sends METHOD=DECLINECOUNTER so the attendee's
+     * ActiveSync client receives clearProposedTimes on the next sync without
+     * requiring the attendee to process the mail in IMP.
+     *
+     * @return boolean  True if the proposal was cleared on the local calendar.
+     */
+    public static function applyDeclineCounterToLocalUser(
+        $recipientEmail,
+        Horde_Icalendar_Vevent $vEvent
+    ) {
+        global $registry;
+
+        if (!$registry->hasMethod('calendar/declineCounterProposal')) {
+            return false;
+        }
+
+        $localUser = Kronolith_FreeBusy::getUserFromEmail($recipientEmail);
+        if (empty($localUser) || $localUser === $registry->getAuth()) {
+            return false;
+        }
+
+        $previousAuth = $registry->getAuth();
+        $previousCreds = $registry->getAuthCredential();
+        if (!is_array($previousCreds)) {
+            $previousCreds = [];
+        }
+
+        try {
+            $registry->setAuth($localUser, []);
+            $registry->call('calendar/declineCounterProposal', [$vEvent]);
+
+            return true;
+        } catch (Horde_Exception $e) {
+            Horde::log($e, Horde_Log::ERR);
+
+            return false;
+        } finally {
+            if ($previousAuth) {
+                $registry->setAuth($previousAuth, $previousCreds);
+            }
+        }
+    }
+
+    /**
+     * Apply a METHOD=REQUEST update directly to a local attendee calendar.
+     *
+     * Only updates an existing copy on the attendee's calendar. New
+     * invitations are not imported server-side so the attendee can accept,
+     * decline, or propose via mail or ActiveSync meeting request.
+     *
+     * @return boolean  True if the event was applied to the local calendar.
+     */
+    protected static function _applyItipRequestToLocalUser(
+        Kronolith_Attendee $attendee,
+        $recipientEmail,
+        $eventUid,
+        Horde_Icalendar_Vevent $vEvent
+    ) {
+        global $registry;
+
+        if (!$registry->hasMethod('calendar/replace')) {
+            return false;
+        }
+
+        if ($attendee->response == self::RESPONSE_NONE) {
+            return false;
+        }
+
+        $localUser = $attendee->user;
+        if (empty($localUser)) {
+            $localUser = Kronolith_FreeBusy::getUserFromEmail($recipientEmail);
+        }
+
+        if (empty($localUser) || $localUser === $registry->getAuth()) {
+            return false;
+        }
+
+        $applied = false;
+        $previousAuth = $registry->getAuth();
+        $previousCreds = $registry->getAuthCredential();
+        if (!is_array($previousCreds)) {
+            $previousCreds = [];
+        }
+        try {
+            $registry->setAuth($localUser, []);
+            try {
+                $calendars = $registry->call('calendar/listCalendars', [true]);
+                $registry->call('calendar/export', [
+                    $eventUid,
+                    'text/calendar',
+                    [],
+                    $calendars,
+                ]);
+            } catch (Horde_Exception $e) {
+                return false;
+            }
+
+            try {
+                $registry->call('calendar/replace', [
+                    $eventUid,
+                    $vEvent,
+                    'text/calendar',
+                ]);
+                $applied = true;
+            } catch (Horde_Exception $e) {
+                return false;
+            }
+
+            if ($applied && $registry->hasMethod('calendar/declineCounterProposal')) {
+                try {
+                    $registry->call('calendar/declineCounterProposal', [$vEvent]);
+                } catch (Horde_Exception $e) {
+                    Horde::log($e, Horde_Log::ERR);
+                }
+            }
+        } finally {
+            if ($previousAuth) {
+                $registry->setAuth($previousAuth, $previousCreds);
+            }
+        }
+
+        return $applied;
     }
 
     /**

--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -2730,9 +2730,7 @@ class Kronolith
 
             return false;
         } finally {
-            if ($previousAuth) {
-                $registry->setAuth($previousAuth, $previousCreds);
-            }
+            $registry->setAuth($previousAuth, $previousCreds);
         }
     }
 
@@ -2809,9 +2807,7 @@ class Kronolith
                 }
             }
         } finally {
-            if ($previousAuth) {
-                $registry->setAuth($previousAuth, $previousCreds);
-            }
+            $registry->setAuth($previousAuth, $previousCreds);
         }
 
         return $applied;

--- a/test/Kronolith/Stub/Registry.php
+++ b/test/Kronolith/Stub/Registry.php
@@ -13,4 +13,18 @@ class Kronolith_Stub_Registry extends Horde_Test_Stub_Registry
     {
         return false;
     }
+
+    public function setAuth($user, $credentials = [])
+    {
+        $this->_user = $user;
+    }
+
+    public function getAuthCredential($credential = null, $app = null)
+    {
+        if (!$this->_user) {
+            return false;
+        }
+
+        return is_null($credential) ? [] : false;
+    }
 }

--- a/test/Kronolith/Unit/EventActiveSyncTest.php
+++ b/test/Kronolith/Unit/EventActiveSyncTest.php
@@ -10,6 +10,7 @@
 
 require_once __DIR__ . '/../Stub/Driver.php';
 require_once __DIR__ . '/../Stub/CalendarManager.php';
+require_once __DIR__ . '/../Stub/Registry.php';
 
 use PHPUnit\Framework\TestCase;
 
@@ -65,6 +66,8 @@ class Kronolith_Unit_EventActiveSyncTest extends TestCase
                 'registry' => 'Horde_Registry',
                 'session' => 'Horde_Session',
             ]);
+            $GLOBALS['registry'] = new Kronolith_Stub_Registry('test@example.com', 'kronolith');
+            $GLOBALS['injector']->setInstance('Horde_Registry', $GLOBALS['registry']);
             $GLOBALS['conf']['prefs']['driver'] = 'Null';
             $GLOBALS['calendar_manager'] = new Kronolith_Stub_CalendarManager();
         }
@@ -249,15 +252,57 @@ class Kronolith_Unit_EventActiveSyncTest extends TestCase
         ]));
         $event->setEasProposalClear(true);
 
-        $GLOBALS['registry']->setAuth('guest@example.com', []);
+        $registry = $GLOBALS['registry'];
+        $previousAuth = $registry->getAuth();
+        $previousCreds = $registry->getAuthCredential();
+        if (!is_array($previousCreds)) {
+            $previousCreds = [];
+        }
+        try {
+            $registry->setAuth('guest@example.com', []);
 
-        $message = $event->toASAppointment([
-            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEENONE,
-        ]);
+            $message = $event->toASAppointment([
+                'protocolversion' => Horde_ActiveSync::VERSION_SIXTEENONE,
+            ]);
 
-        $attendees = $message->getAttendees();
-        $this->assertCount(1, $attendees);
-        $this->assertTrue($attendees[0]->clearProposedTimes);
+            $attendees = $message->getAttendees();
+            $this->assertCount(1, $attendees);
+            $this->assertTrue($attendees[0]->clearProposedTimes);
+        } finally {
+            $registry->setAuth($previousAuth, $previousCreds);
+        }
+    }
+
+    public function testToASAppointmentClearsProposedTimesForAttendeeUserId()
+    {
+        $event = $this->_createEvent();
+        $event->status = Kronolith::STATUS_CONFIRMED;
+        $event->attendees->add(new Kronolith_Attendee([
+            'user' => 'guest@example.com',
+            'name' => 'Guest',
+            'response' => Kronolith::RESPONSE_TENTATIVE,
+        ]));
+        $event->setEasProposalClear(true);
+
+        $registry = $GLOBALS['registry'];
+        $previousAuth = $registry->getAuth();
+        $previousCreds = $registry->getAuthCredential();
+        if (!is_array($previousCreds)) {
+            $previousCreds = [];
+        }
+        try {
+            $registry->setAuth('guest@example.com', []);
+
+            $message = $event->toASAppointment([
+                'protocolversion' => Horde_ActiveSync::VERSION_SIXTEENONE,
+            ]);
+
+            $attendees = $message->getAttendees();
+            $this->assertCount(1, $attendees);
+            $this->assertTrue($attendees[0]->clearProposedTimes);
+        } finally {
+            $registry->setAuth($previousAuth, $previousCreds);
+        }
     }
 
     public function testDisallowNewTimeProposalRoundTrip()

--- a/test/Kronolith/Unit/EventActiveSyncTest.php
+++ b/test/Kronolith/Unit/EventActiveSyncTest.php
@@ -238,6 +238,28 @@ class Kronolith_Unit_EventActiveSyncTest extends TestCase
         );
     }
 
+    public function testToASAppointmentClearsProposedTimesWhenRequested()
+    {
+        $event = $this->_createEvent();
+        $event->status = Kronolith::STATUS_CONFIRMED;
+        $event->attendees->add(new Kronolith_Attendee([
+            'email' => 'guest@example.com',
+            'name' => 'Guest',
+            'response' => Kronolith::RESPONSE_TENTATIVE,
+        ]));
+        $event->setEasProposalClear(true);
+
+        $GLOBALS['registry']->setAuth('guest@example.com', []);
+
+        $message = $event->toASAppointment([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEENONE,
+        ]);
+
+        $attendees = $message->getAttendees();
+        $this->assertCount(1, $attendees);
+        $this->assertTrue($attendees[0]->clearProposedTimes);
+    }
+
     public function testDisallowNewTimeProposalRoundTrip()
     {
         $event = $this->_createEvent();


### PR DESCRIPTION
## Summary

- Add registry APIs for EAS 16.1 counter-proposals: store proposed times, accept/decline on the organizer or attendee calendar.
- Export `clearProposedTimes` on ActiveSync sync when a counter-proposal is cleared, so iOS removes the “propose new time” UI (not via DECLINECOUNTER mail alone).
- Improve iTip delivery: resolve local user emails, optional limited recipient lists, server-side calendar apply for REQUEST updates without auto-importing new invitations.

## Motivation

EAS 16.1 lets clients propose new meeting times via `MeetingResponse` with `ProposedStartTime`/`ProposedEndTime`. When the organizer declines, RFC 5546 sends `METHOD=DECLINECOUNTER` mail, but iOS only clears the in-calendar proposal after a **calendar Sync** with empty proposed-time elements on the attendee record. Kronolith must persist proposals, clear them on decline, and signal the next ActiveSync export.

Manual testing confirmed the full flow on iOS 16.1 (propose → organizer decline in IMP → proposal removed on device after sync).

## Changes

### `lib/Api.php`
- `acceptCounterProposal()` — clear proposal metadata on organizer event, bump sequence, send REQUEST to attendees.
- `declineCounterProposal()` — clear `proposedStart`/`proposedEnd`; on attendee calendar set `X-HORDE-EAS-PROPOSAL-CLEAR`; optional targeted REQUEST notify.
- `storeAttendeeProposal()` — persist proposed times on an attendee record (ActiveSync inbound).
- `_getEditableEventByUid()` — shared helper for UID lookup on editable calendars.
- `_authAttendeeHasProposal()` — detect proposal removal during `replace()` and queue EAS clear.
- ActiveSync export: consume one-shot clear flag after successful export.

### `lib/Kronolith.php`
- `sendITipNotifications()`: `$limitedAttendees`, local-user email resolution, clear stale proposals on REQUEST, `_applyItipRequestToLocalUser()` for server-side calendar updates (replace only if event exists; skip `RESPONSE_NONE` invitations).
- `applyDeclineCounterToLocalUser()` — switch to attendee auth, call `calendar/declineCounterProposal`, restore credentials (incl. SMTP).
- Minor: default attendee email in internal calendar list.

### `lib/Event.php`
- `EAS_PROPOSAL_CLEAR_ATTRIBUTE`, `needsEasProposalClear()`, `setEasProposalClear()`.
- `toASAppointment()`: set `clearProposedTimes` on current user's attendee when flag is pending (EAS ≥ 16.1).

### `test/Kronolith/Unit/EventActiveSyncTest.php`
- `testToASAppointmentClearsProposedTimesWhenRequested()`.

## Dependencies

This PR is **not sufficient alone**. Deploy together with:

| Package | Key files |
|---------|-----------|
| **horde/activesync** | `Message/Attendee.php` — emit empty `ProposedStartTime`/`ProposedEndTime` WBXML tags (`output_empty=true`) |
| **horde/imp** | `Ajax/Imple/ItipRequest.php` — wire accept/decline counter actions, call `applyDeclineCounterToLocalUser()` before DECLINECOUNTER mail |

## Test plan

- [ ] `vendor/bin/phpunit -c vendor/horde/kronolith/phpunit.xml.dist test/Kronolith/Unit/EventActiveSyncTest.php`
- [ ] EAS 16.1 manual: attendee proposes new time → organizer declines in IMP → attendee iOS calendar clears proposal after sync (see deployment `docs/EAS-16.1-manual-testing.md` Phase 3B)
- [ ] New invitation: attendee still sees accept/decline/propose (not auto-accepted)
- [ ] Local attendee receives iTip mail when organizer updates/declines
- [ ] With activesync + imp PRs merged: full iOS end-to-end pass