### PR TITLE
fix(kronolith): show events in This Month portal block

### DIFF
--- a/lib/Block/Month.php
+++ b/lib/Block/Month.php
@@ -72,6 +72,14 @@ class Kronolith_Block_Month extends Horde_Core_Block
     {
         $on_day = [];
 
+        $dayStart = clone $day;
+        $dayStart->hour = 0;
+        $dayStart->min = 0;
+        $dayStart->sec = 0;
+
+        $dayEnd = clone $dayStart;
+        $dayEnd->mday++;
+
         foreach ($all_events as $events) {
             if (!is_array($events)) {
                 continue;
@@ -80,8 +88,9 @@ class Kronolith_Block_Month extends Horde_Core_Block
                 if (!($event instanceof Kronolith_Event)) {
                     continue;
                 }
-                if ($event->start->compareDate($day) > 0
-                    || $event->end->compareDate($day) < 0) {
+                // Treat end time as exclusive so events ending at 00:00 don't spill into the next day.
+                if ($event->start->compareDateTime($dayEnd) >= 0
+                    || $event->end->compareDateTime($dayStart) <= 0) {
                     continue;
                 }
                 $on_day[$event->id] = $event;
@@ -89,7 +98,6 @@ class Kronolith_Block_Month extends Horde_Core_Block
         }
 
         return $on_day;
-    }
 
     /**
      */

--- a/lib/Block/Month.php
+++ b/lib/Block/Month.php
@@ -58,10 +58,48 @@ class Kronolith_Block_Month extends Horde_Core_Block
     }
 
     /**
+     * Return events occurring on the given calendar day.
+     *
+     * Events are loaded with cover_dates disabled (like the Upcoming Events
+     * block). Match by date span so multi-day events appear on each day.
+     *
+     * @param array $all_events  Events from listEvents().
+     * @param Horde_Date $day    The day to check.
+     *
+     * @return Kronolith_Event[]
+     */
+    protected function _eventsForDay(array $all_events, Horde_Date $day)
+    {
+        $on_day = [];
+
+        foreach ($all_events as $events) {
+            if (!is_array($events)) {
+                continue;
+            }
+            foreach ($events as $event) {
+                if (!($event instanceof Kronolith_Event)) {
+                    continue;
+                }
+                if ($event->start->compareDate($day) > 0
+                    || $event->end->compareDate($day) < 0) {
+                    continue;
+                }
+                $on_day[$event->id] = $event;
+            }
+        }
+
+        return $on_day;
+    }
+
+    /**
      */
     protected function _content()
     {
         global $prefs;
+
+        if (empty($GLOBALS['calendar_manager'])) {
+            Kronolith::initialize();
+        }
 
         if (isset($this->_params['calendar'])
             && $this->_params['calendar'] != '__all') {
@@ -74,34 +112,40 @@ class Kronolith_Block_Month extends Horde_Core_Block
             }
         }
 
-        $year = date('Y');
-        $month = date('m');
+        $now = new Horde_Date($_SERVER['REQUEST_TIME']);
+        $year = $now->year;
+        $month = $now->month;
+        $weekStartMonday = (bool) $prefs->getValue('week_start_monday');
+
         $startday = new Horde_Date(['mday' => 1,
             'month' => $month,
             'year' => $year]);
         $startday = $startday->dayOfWeek();
-        if (!$prefs->getValue('week_start_monday')) {
+        if (!$weekStartMonday) {
             $startOfView = 1 - $startday;
-            $endday = new Horde_Date(['mday' => Horde_Date_Utils::daysInMonth($month, $year),
-                'month' => $month,
-                'year' => $year]);
+        } elseif ($startday == Horde_Date::DATE_SUNDAY) {
+            $startOfView = -5;
         } else {
-            if ($startday == Horde_Date::DATE_SUNDAY) {
-                $startOfView = -5;
-            } else {
-                $startOfView = 2 - $startday;
-            }
+            $startOfView = 2 - $startday;
         }
 
-        $startDate = new Horde_Date($year, $month, $startOfView);
-        $endDate = new Horde_Date(
-            $year,
-            $month,
-            Horde_Date_Utils::daysInMonth($month, $year) + 1
-        );
+        $startDate = new Horde_Date([
+            'year' => $year,
+            'month' => $month,
+            'mday' => $startOfView,
+        ]);
+        $endDate = new Horde_Date([
+            'year' => $year,
+            'month' => $month,
+            'mday' => Horde_Date_Utils::daysInMonth($month, $year) + 1,
+        ]);
         $endDate->mday
-            += (7 - ($endDate->format('w') - $prefs->getValue('week_start_monday')))
-            % 7;
+            += (7 - ($endDate->format('w') - ($weekStartMonday ? 1 : 0))) % 7;
+
+        $listOptions = [
+            'show_recurrence' => true,
+            'cover_dates' => false,
+        ];
 
         /* Table start. and current month indicator. */
         $html = '<table cellspacing="1" class="monthgrid" width="100%"><tr>';
@@ -122,18 +166,29 @@ class Kronolith_Block_Month extends Horde_Core_Block
                 && $this->_params['calendar'] != '__all') {
                 [$type, $calendar] = explode('_', $this->_params['calendar'], 2);
                 $driver = Kronolith::getDriver($type, $calendar);
-                $all_events = $driver->listEvents($startDate, $endDate, [
-                    'show_recurrence' => true]);
+                $all_events = $driver->listEvents(
+                    $startDate,
+                    $endDate,
+                    $listOptions
+                );
             } else {
-                $all_events = Kronolith::listEvents($startDate, $endDate, $GLOBALS['calendar_manager']->get(Kronolith::DISPLAY_CALENDARS));
+                $all_events = Kronolith::listEvents(
+                    $startDate,
+                    $endDate,
+                    null,
+                    $listOptions
+                );
             }
-        } catch (Exception $e) {
-            return '<em>' . $e->getMessage() . '</em>';
+        } catch (Horde_Exception $e) {
+            Horde::log($e, Horde_Log::ERR);
+            return '<em>' . htmlspecialchars($e->getMessage()) . '</em>';
+        }
+        if (!is_array($all_events)) {
+            $all_events = [];
         }
 
         $weekday = 0;
         $week = -1;
-        $weekStart = $prefs->getValue('week_start_monday');
         for ($date_ob = new Kronolith_Day($month, $startOfView, $year);
             $date_ob->compareDate($endDate) < 0;
             $date_ob->mday++) {
@@ -145,7 +200,6 @@ class Kronolith_Block_Month extends Horde_Core_Block
                 $html .= '</tr><tr>';
             }
 
-            ;
             if ($date_ob->isToday()) {
                 $td_class = 'kronolith-today';
             } elseif ($date_ob->month != $month) {
@@ -165,15 +219,15 @@ class Kronolith_Block_Month extends Horde_Core_Block
                 $url->add('display_cal', $this->_params['calendar']);
             }
 
-            $date_stamp = $date_ob->dateString();
-            if (empty($all_events[$date_stamp])) {
+            $day_events_list = $this->_eventsForDay($all_events, $date_ob);
+            if (empty($day_events_list)) {
                 /* No events, plain link to the day. */
                 $cell = Horde::linkTooltip($url, _("View Day")) . $date_ob->mday . '</a>';
             } else {
                 /* There are events; create a cell with tooltip to
                  * list them. */
                 $day_events = '';
-                foreach ($all_events[$date_stamp] as $event) {
+                foreach ($day_events_list as $event) {
                     if ($event->isAllDay()) {
                         $day_events .= _("All day");
                     } else {
@@ -188,7 +242,7 @@ class Kronolith_Block_Month extends Horde_Core_Block
             }
 
             /* Bold the cell if there are events. */
-            if (!empty($all_events[$date_stamp])) {
+            if (!empty($day_events_list)) {
                 $cell = '<strong>' . $cell . '</strong>';
             }
 


### PR DESCRIPTION
## Summary
- Load events for the month grid like the working Upcoming Events portal block
- Map events onto calendar days by date span, including multi-day events
- Use request time for the current month and ensure `calendar_manager` is initialized

## Motivation
The classic portal block "This Month" showed an empty month grid even when the same events were visible in Kronolith and in the "Upcoming Events" portal block.

## Changes
- `lib/Block/Month.php`: add `_eventsForDay()`, use `cover_dates => false`, align date range setup with other portal blocks

## Test plan
- [ ] Add the "This Month" block to `/horde/services/portal/`
- [ ] Confirm events visible in Kronolith appear bold on the correct days
- [ ] Test with "All Visible" and with a specific calendar selected
- [ ] Compare with the "Upcoming Events" block for the same test event

Made with [Cursor](https://cursor.com)