### PR TITLE
feat(kronolith): organizer UI for disallow new time proposals

### DIFF
--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -5859,6 +5859,8 @@ KronolithCore = {
         this.freeBusyData = $H();
         this._clearFBTableBody('kronolithEventAttendeesList');
         this._clearFBTableBody('kronolithEventResourcesList');
+        $('kronolithEventDisallowNewTimeProposal').setValue(false);
+        $('kronolithEventDisallowCounter').hide();
         $('kronolithFBLoading').hide();
         $('kronolithResourceFBLoading').hide();
         this.updateCalendarDropDown('kronolithEventTarget');
@@ -5922,6 +5924,8 @@ KronolithCore = {
             $('kronolithEventId').clear();
             $('kronolithEventCalendar').clear();
             $('kronolithEventAttend').hide();
+            $('kronolithEventDisallowNewTimeProposal').setValue(false);
+            $('kronolithEventDisallowCounter').hide();
             $('kronolithEventTarget').setValue(Kronolith.conf.default_calendar);
             $('kronolithEventDelete').hide();
             $('kronolithEventStartDate').setValue(d.toString(Kronolith.conf.date_format));
@@ -6233,6 +6237,7 @@ KronolithCore = {
         $('kronolithEventStatus').setValue(ev.x);
         $('kronolithEventDescription').setValue(ev.d);
         $('kronolithEventPrivate').setValue(ev.pv);
+        $('kronolithEventDisallowNewTimeProposal').setValue(!!ev.dntp);
         $('kronolithEventLinkExport').up('li').show();
         $('kronolithEventExport').href = Kronolith.conf.URI_EVENT_EXPORT.interpolate({ id: ev.id, calendar: ev.c, type: ev.ty });
 
@@ -6355,6 +6360,7 @@ KronolithCore = {
                 }
             }
         }
+        this.toggleDisallowNewTimeProposal();
 
         /* Resources */
         if (typeof ev.rs !== 'undefined') {
@@ -6478,6 +6484,30 @@ KronolithCore = {
     },
 
     /**
+     * Shows or hides the disallow-counter option for meeting organizers.
+     */
+    toggleDisallowNewTimeProposal: function()
+    {
+        var div = $('kronolithEventDisallowCounter');
+
+        if (!div) {
+            return;
+        }
+
+        var show = !$F('kronolithEventOrganizer') &&
+            ($F('kronolithEventUsers') ||
+             $F('kronolithEventAttendees') ||
+             this.attendees.length > 0);
+
+        if (show) {
+            div.show();
+        } else {
+            div.hide();
+            $('kronolithEventDisallowNewTimeProposal').setValue(false);
+        }
+    },
+
+    /**
      * Adds an attendee row to the free/busy table.
      *
      * @param string|object attendee  An attendee string or an object with the
@@ -6509,6 +6539,7 @@ KronolithCore = {
         }
 
         this.insertFBRow(attendee);
+        this.toggleDisallowNewTimeProposal();
     },
 
     /**
@@ -6595,6 +6626,7 @@ KronolithCore = {
         });
 
         this.insertFBRow(user);
+        this.toggleDisallowNewTimeProposal();
     },
 
     /**
@@ -6869,6 +6901,7 @@ KronolithCore = {
         var row = this.freeBusyRows.get(attendee.i);
         row.purge();
         row.remove();
+        this.toggleDisallowNewTimeProposal();
     },
 
     /**
@@ -6884,6 +6917,7 @@ KronolithCore = {
           row.purge();
           row.remove();
         }
+        this.toggleDisallowNewTimeProposal();
     },
 
     normalizeAttendee: function(attendee)

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -1872,6 +1872,22 @@ abstract class Kronolith_Event
     }
 
     /**
+     * Whether attendees are forbidden from proposing new meeting times.
+     */
+    public function disallowsNewTimeProposal(): bool
+    {
+        return $this->_disallowsNewTimeProposal();
+    }
+
+    /**
+     * Store or clear the disallow-counter flag for attendee time proposals.
+     */
+    public function setDisallowNewTimeProposal(bool $disallow): void
+    {
+        $this->_setDisallowCounter($disallow);
+    }
+
+    /**
      * Import an EAS 16 AirSyncBase:Location object into event fields.
      */
     protected function _importEasLocation($location): void
@@ -3338,6 +3354,7 @@ abstract class Kronolith_Event
             $json->tz = $this->timezone;
             $json->a = $this->alarm;
             $json->pv = $this->private;
+            $json->dntp = $this->_disallowsNewTimeProposal();
             if ($this->recurs()) {
                 $json->r = $this->recurrence->toJson();
             }
@@ -3926,6 +3943,10 @@ abstract class Kronolith_Event
             $attendees = $finalAttendees;
         }
         $this->attendees = $attendees;
+
+        if (!$this->organizer) {
+            $this->_setDisallowCounter((bool) Util::getFormData('disallownewtimeproposal'));
+        }
 
         // Event start.
         $allDay = Util::getFormData('whole_day');

--- a/templates/dynamic/edit.inc
+++ b/templates/dynamic/edit.inc
@@ -234,6 +234,12 @@
 </div>
 
 <div id="kronolithEventTabAttendees" class="kronolithTabsOption" style="display:none">
+  <div id="kronolithEventDisallowCounter" style="display:none">
+    <p>
+      <input type="checkbox" name="disallownewtimeproposal" id="kronolithEventDisallowNewTimeProposal" value="1" tabindex="7" />
+      <label for="kronolithEventDisallowNewTimeProposal"><?php echo _("Do not allow attendees to propose new times") ?></label>
+    </p>
+  </div>
   <label for="kronolithEventUsers"><?php echo _("Add users") ?>:</label>
   <span class="kronolithSeparator">&mdash; <?php echo _("separate users with a comma") ?></span>
   <br />

--- a/templates/dynamic/edit.inc
+++ b/templates/dynamic/edit.inc
@@ -236,7 +236,7 @@
 <div id="kronolithEventTabAttendees" class="kronolithTabsOption" style="display:none">
   <div id="kronolithEventDisallowCounter" style="display:none">
     <p>
-      <input type="checkbox" name="disallownewtimeproposal" id="kronolithEventDisallowNewTimeProposal" value="1" tabindex="7" />
+      <input type="checkbox" name="disallownewtimeproposal" id="kronolithEventDisallowNewTimeProposal" value="1" />
       <label for="kronolithEventDisallowNewTimeProposal"><?php echo _("Do not allow attendees to propose new times") ?></label>
     </p>
   </div>

--- a/test/Kronolith/Unit/EventActiveSyncTest.php
+++ b/test/Kronolith/Unit/EventActiveSyncTest.php
@@ -34,6 +34,11 @@ class Kronolith_Unit_TestActiveSyncEvent extends Kronolith_Event
         return [];
     }
 
+    public function vfsInit()
+    {
+        return false;
+    }
+
     public function isPrivate($user = null)
     {
         return (bool) $this->private;
@@ -68,6 +73,7 @@ class Kronolith_Unit_EventActiveSyncTest extends TestCase
             ]);
             $GLOBALS['registry'] = new Kronolith_Stub_Registry('test@example.com', 'kronolith');
             $GLOBALS['injector']->setInstance('Horde_Registry', $GLOBALS['registry']);
+            $GLOBALS['injector']->bindFactory('Kronolith_Geo', 'Kronolith_Factory_Geo', 'create');
             $GLOBALS['conf']['prefs']['driver'] = 'Null';
             $GLOBALS['calendar_manager'] = new Kronolith_Stub_CalendarManager();
         }
@@ -325,5 +331,54 @@ class Kronolith_Unit_EventActiveSyncTest extends TestCase
             'protocolversion' => Horde_ActiveSync::VERSION_TWELVEONE,
         ]);
         $this->assertEmpty($legacy->disallownewtimeproposal);
+    }
+
+    public function testReadFormSetsDisallowNewTimeProposalForOrganizer()
+    {
+        $event = $this->_createEvent();
+        $_POST['disallownewtimeproposal'] = '1';
+
+        $event->readForm();
+
+        $this->assertTrue($event->disallowsNewTimeProposal());
+        unset($_POST['disallownewtimeproposal']);
+    }
+
+    public function testReadFormDoesNotClearDisallowNewTimeProposalForAttendee()
+    {
+        $event = $this->_createEvent();
+        $event->setDisallowNewTimeProposal(true);
+        $_POST['organizer'] = 'organizer@example.test';
+
+        $event->readForm();
+
+        $this->assertTrue($event->disallowsNewTimeProposal());
+        unset($_POST['organizer']);
+    }
+
+    public function testToJsonExportsDisallowNewTimeProposal()
+    {
+        $event = $this->_createEvent();
+        $event->setDisallowNewTimeProposal(true);
+
+        $json = $event->toJson(['full' => true]);
+
+        $this->assertTrue($json->dntp);
+    }
+
+    public function testIcalendarRoundTripPreservesDisallowNewTimeProposal()
+    {
+        $event = $this->_createEvent();
+        $event->setDisallowNewTimeProposal(true);
+
+        $calendar = new Horde_Icalendar();
+        $vevents = $event->toiCalendar($calendar);
+        $this->assertNotEmpty($vevents);
+        $this->assertSame('TRUE', $vevents[0]->getAttribute('DISALLOW-COUNTER'));
+
+        $imported = new Kronolith_Unit_TestActiveSyncEvent(new Kronolith_Stub_Driver());
+        $imported->fromiCalendar($vevents[0]);
+
+        $this->assertTrue($imported->disallowsNewTimeProposal());
     }
 }


### PR DESCRIPTION
## Summary
- Add organizer checkbox on the Attendees tab to forbid attendee time proposals (EAS 16.1 / DISALLOW-COUNTER)
- Wire `readForm`, full JSON export (`dntp`), and JS visibility toggling for organizer events with attendees
- Extend unit tests for form handling, JSON export, and iCal round-trip

## Motivation
Backend support for `DisallowNewTimeProposal` / `DISALLOW-COUNTER` already existed for ActiveSync calendar sync and meeting responses, but organizers had no UI to set the flag. Phase 3C manual testing required a Kronolith editor control.

## Changes
- `lib/Event.php`: public `disallowsNewTimeProposal()` / `setDisallowNewTimeProposal()`, `readForm` + `toJson` wiring
- `templates/dynamic/edit.inc`, `js/kronolith.js`: checkbox and show/hide logic
- `test/Kronolith/Unit/EventActiveSyncTest.php`: form, JSON, iCal tests

## Test plan
- [x] `vendor/bin/phpunit -c phpunit.xml.dist test/Kronolith/Unit/EventActiveSyncTest.php` (13 tests)
- [x] Manual EAS 16.1 Phase 3C: organizer sets flag, calendar sync exports `POOMCAL:DisallowNewTimeProposal=1`, iOS no longer offers propose-alternative

Made with [Cursor](https://cursor.com)