### PR TITLE
fix(kronolith): group sidebar share icon with action controls

### DIFF
--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -1001,7 +1001,7 @@ KronolithCore = {
         calendar.insert(
             new Element('div', { className: 'horde-resource-link' })
                 .insert(link));
-        this.addShareIcon(cal, link);
+        this.addShareIcon(cal, calendar);
         div.insert(calendar);
         if (cal.show) {
             this.addCalendarLegend(type, id, cal);
@@ -1009,19 +1009,34 @@ KronolithCore = {
     },
 
     /**
-     * Add the share icon after the calendar name in the calendar list.
+     * Add the share icon to a calendar/tasklist row in the sidebar menu.
      *
-     * @param object cal       A calendar object from Kronolith.conf.calendars.
-     * @param Element element  The calendar element in the list.
+     * @param object cal   A calendar object from Kronolith.conf.calendars.
+     * @param Element row  The calendar row element in the list.
      */
-    addShareIcon: function(cal, element)
+    addShareIcon: function(cal, row)
     {
+        row.select('[class*="horde-resource-share-"]').invoke('remove');
         if (cal.owner && cal.perms) {
             $H(cal.perms).each(function(perm) {
                 if (perm.key != 'type' &&
                     ((Object.isArray(perm.value) && perm.value.size()) ||
                      (!Object.isArray(perm.value) && perm.value))) {
-                    element.insert(' ').insert(new Element('img', { src: Kronolith.conf.images.attendees.replace(/fff/, cal.fg.substring(1)), title: Kronolith.text.shared }));
+                    var linkDiv = row.down('.horde-resource-link');
+                    if (!linkDiv) {
+                        return;
+                    }
+                    linkDiv.insert({
+                        before: new Element('span', {
+                            className: 'horde-resource-share-' + cal.fg.substring(1),
+                            title: Kronolith.text.shared
+                        }).setStyle({ backgroundColor: cal.bg, color: cal.fg })
+                            .insert(new Element('img', {
+                                src: Kronolith.conf.images.attendees.replace(/fff/, cal.fg.substring(1)),
+                                alt: '',
+                                title: Kronolith.text.shared
+                            }))
+                    });
                     throw $break;
                 }
             });
@@ -3939,7 +3954,7 @@ KronolithCore = {
                         var link = element.down('.horde-resource-link span');
                         element.setStyle(color);
                         link.update(cal.name.escapeHTML());
-                        this.addShareIcon(cal, link);
+                        this.addShareIcon(cal, element);
                         throw $break;
                     }
                 }, this);

--- a/themes/default/dynamic/screen.css
+++ b/themes/default/dynamic/screen.css
@@ -94,7 +94,7 @@ html, body {
 }
 #horde-sidebar div.horde-resources .horde-resource-edit-000,
 #horde-sidebar div.horde-resources .horde-resource-edit-fff {
-    margin-right: 5px;
+    margin: 2px 2px 0 0;
 }
 /* @todo move to horde. */
 #horde-sidebar div.horde-resources .horde-resource-refresh-000,
@@ -106,7 +106,7 @@ html, body {
     background-repeat: no-repeat;
     background-position: center center;
     background-size: 16px 16px;
-    margin: 2px 10px 0 0;
+    margin: 2px 5px 0 0;
     width: 17px;
     height: 17px;
     text-indent: -10000px;
@@ -115,6 +115,25 @@ html, body {
 }
 #horde-sidebar div.horde-resources .horde-resource-refresh-fff {
     background-image: url("../graphics/refresh-sidebar-fff.png");
+}
+/* Share icon grouped with edit/refresh on the right of sidebar rows. */
+#horde-sidebar div.horde-resources .horde-resource-share-000,
+#horde-sidebar div.horde-resources .horde-resource-share-fff {
+    float: right;
+    display: block;
+    background-color: transparent;
+    margin: 2px 2px 0 0;
+    width: 17px;
+    height: 17px;
+    text-align: center;
+    overflow: hidden;
+    cursor: default;
+}
+#horde-sidebar div.horde-resources .horde-resource-share-000 img,
+#horde-sidebar div.horde-resources .horde-resource-share-fff img {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
 }
 
 /* Quick edit */

--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -296,6 +296,25 @@ img.kronolithEventIcon {
    attendees view. The Lucide icon-set bump replaced edit.png and
    delete.png with 48x48 assets; constrain the rendered <img> so they
    stay inline-sized in portal blocks and the basic event list. */
+/* Share icon grouped with edit/refresh on the right of sidebar rows. */
+#horde-sidebar div.horde-resources .horde-resource-share-000,
+#horde-sidebar div.horde-resources .horde-resource-share-fff {
+    float: right;
+    display: block;
+    background-color: transparent;
+    margin: 2px 2px 0 0;
+    width: 17px;
+    height: 17px;
+    text-align: center;
+    overflow: hidden;
+    cursor: default;
+}
+#horde-sidebar div.horde-resources .horde-resource-share-000 img,
+#horde-sidebar div.horde-resources .horde-resource-share-fff img {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+}
 img.iconAlarm,
 img.iconRecur,
 img.iconException,


### PR DESCRIPTION
## Summary
- Float the shared calendar/tasklist indicator with refresh/edit on the right of sidebar rows
- Constrain oversized attendees graphics after the Lucide asset bump

## Motivation
After the icon modernization, the share icon rendered too large inline with wrapped resource names while edit/refresh stayed on the right edge.

## Changes
- Move share icon insertion in `addShareIcon()` out of the label span and into the row action group
- Add sidebar CSS for `.horde-resource-share-*` and tighten action icon spacing
- Keep attendees `<img>` sizing rules for event/status views

## Test plan
- [ ] Open Kronolith dynamic view with a shared tasklist/calendar in the sidebar
- [ ] Verify share, edit, and refresh icons stay grouped on the right when the name wraps
- [ ] Create/edit an event and confirm attendee remove buttons still render at 16x16
