### PR TITLE
Fix two crashes in editCalendar() (RedBox.onDisplay recursion, null PGList)

### DIFF
--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -2706,7 +2706,12 @@ KronolithCore = {
 
         this.closeRedBox();
         this.quickClose();
-        this.redBoxOnDisplay = RedBox.onDisplay;
+        // Avoid re-wrapping onDisplay: if it is already our wrapper, keep the
+        // original handler already captured (prevents self-reference -> infinite
+        // recursion when the dialog is opened again before it was displayed).
+        if (!RedBox.onDisplay || !RedBox.onDisplay._kronolithWrap) {
+            this.redBoxOnDisplay = RedBox.onDisplay;
+        }
         RedBox.onDisplay = function() {
             if (this.redBoxOnDisplay) {
                 this.redBoxOnDisplay();
@@ -2716,6 +2721,7 @@ KronolithCore = {
             } catch(e) {}
             RedBox.onDisplay = this.redBoxOnDisplay;
         }.bind(this);
+        RedBox.onDisplay._kronolithWrap = true;
 
         this.openTab($('kronolithTaskForm').down('.tabset a.kronolithTabLink'));
         $('kronolithTaskForm').enable();
@@ -3103,7 +3109,12 @@ KronolithCore = {
             return;
         }
 
-        this.redBoxOnDisplay = RedBox.onDisplay;
+        // Avoid re-wrapping onDisplay: if it is already our wrapper, keep the
+        // original handler already captured (prevents self-reference -> infinite
+        // recursion when the dialog is opened again before it was displayed).
+        if (!RedBox.onDisplay || !RedBox.onDisplay._kronolithWrap) {
+            this.redBoxOnDisplay = RedBox.onDisplay;
+        }
         RedBox.onDisplay = function() {
             if (this.redBoxOnDisplay) {
                 this.redBoxOnDisplay();
@@ -3113,6 +3124,7 @@ KronolithCore = {
             } catch(e) {}
             RedBox.onDisplay = this.redBoxOnDisplay;
         }.bind(this);
+        RedBox.onDisplay._kronolithWrap = true;
 
         if ($('kronolithCalendarDialog')) {
             this.redBoxLoading = true;
@@ -3128,10 +3140,17 @@ KronolithCore = {
                         this.redBoxLoading = true;
                         RedBox.showHtml(r.chunk);
                         ['internal', 'tasklists'].each(function(type) {
-                            $('kronolithC' + type + 'PGList').observe('change', function() {
-                                $('kronolithC' + type + 'PG').setValue(1);
-                                this.permsClickHandler(type, 'G');
-                            }.bind(this));
+                            // Guard against a missing element: not all calendar
+                            // types render a PGList <select>. Calling observe() on
+                            // null threw and aborted the callback, leaving the
+                            // dialog empty.
+                            var pgList = $('kronolithC' + type + 'PGList');
+                            if (pgList) {
+                                pgList.observe('change', function() {
+                                    $('kronolithC' + type + 'PG').setValue(1);
+                                    this.permsClickHandler(type, 'G');
+                                }.bind(this));
+                            }
                         }, this);
                         this.editCalendarCallback(calendar);
                     } else {
@@ -5849,7 +5868,12 @@ KronolithCore = {
 
         this.closeRedBox();
         this.quickClose();
-        this.redBoxOnDisplay = RedBox.onDisplay;
+        // Avoid re-wrapping onDisplay: if it is already our wrapper, keep the
+        // original handler already captured (prevents self-reference -> infinite
+        // recursion when the dialog is opened again before it was displayed).
+        if (!RedBox.onDisplay || !RedBox.onDisplay._kronolithWrap) {
+            this.redBoxOnDisplay = RedBox.onDisplay;
+        }
         RedBox.onDisplay = function() {
             if (this.redBoxOnDisplay) {
                 this.redBoxOnDisplay();
@@ -5865,6 +5889,7 @@ KronolithCore = {
             }
             RedBox.onDisplay = this.redBoxOnDisplay;
         }.bind(this);
+        RedBox.onDisplay._kronolithWrap = true;
         this._ensureEventDialogInBody();
         this._resetEventAutoCompleters(['kronolithEventUsers', 'kronolithEventAttendees']);
         this.attendees = [];


### PR DESCRIPTION
While investigating #65 (empty calendar dialog), two latent JS crashes in
`editCalendar()` surfaced. Neither is the root cause of #65 — that is in
horde/core `redbox.js` (see horde/Core#185) — but both crash when triggered
and are worth fixing.

## 1. Infinite recursion of `RedBox.onDisplay`

The save/restore pattern for `RedBox.onDisplay` (duplicated in `editEvent`,
`editCalendar`, `editTask`) shares `this.redBoxOnDisplay`. If a dialog is
opened again before the previous one was displayed (so `onDisplay` never ran
its restore), the next call captures **its own wrapper** into
`redBoxOnDisplay`, which then calls itself → `RangeError: Maximum call stack
size exceeded`.

Fix: tag the wrapper and skip re-capturing it, so `redBoxOnDisplay` always
holds the original handler, never a wrapper.

## 2. `.observe()` on a null PGList element

```js
$('kronolithC' + type + 'PGList').observe('change', ...)
```

The tasklists `PGList` `<select>` may not be present; `$(...)` returns null and
`.observe()` throws, aborting the callback. Guarded with an existence check.

## Testing

Verified on a live H6 dev instance: combined with horde/Core#185, the calendar
create/edit dialog renders correctly and no longer throws.

Refs #65
