### PR TITLE
Use WCAG contrast ratio for calendar foreground color

### DIFF
--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -3399,6 +3399,30 @@ KronolithCore = {
     },
 
     /**
+     * Returns '#fff' or '#000', whichever has the higher WCAG contrast ratio
+     * against the given background color. More accurate than the legacy YIQ
+     * brightness threshold, which mislabeled some saturated colors (e.g.
+     * magenta) as needing white text below the AA contrast minimum.
+     *
+     * @param string bg  The hex background color.
+     *
+     * @return string  '#fff' or '#000'.
+     */
+    contrastColor: function(bg)
+    {
+        var rgb = Color.hex2rgb(bg),
+            lum = function(c) {
+                c = c / 255;
+                return (c <= 0.03928) ? c / 12.92
+                                      : Math.pow((c + 0.055) / 1.055, 2.4);
+            },
+            l = 0.2126 * lum(rgb[0]) + 0.7152 * lum(rgb[1]) + 0.0722 * lum(rgb[2]),
+            cLight = (1.0 + 0.05) / (l + 0.05),
+            cDark = (l + 0.05) / (0.0 + 0.05);
+        return (cLight >= cDark) ? '#fff' : '#000';
+    },
+
+    /**
      * Updates the color field in a calendar dialog.
      *
      * @param string type   The calendar type.
@@ -3418,7 +3442,7 @@ KronolithCore = {
             .setValue(color)
             .setStyle({
                 backgroundColor: color,
-                color: Color.brightness(Color.hex2rgb(color)) < 125 ? '#fff' : '#000'
+                color: this.contrastColor(color)
             });
     },
 

--- a/lib/Calendar.php
+++ b/lib/Calendar.php
@@ -77,7 +77,7 @@ abstract class Kronolith_Calendar
      */
     public function foreground()
     {
-        return Horde_Image::brightness($this->background()) < 128 ? '#fff' : '#000';
+        return Horde_Image::contrastColor($this->background(), '#fff', '#000');
     }
 
     /**

--- a/lib/Calendar.php
+++ b/lib/Calendar.php
@@ -77,7 +77,9 @@ abstract class Kronolith_Calendar
      */
     public function foreground()
     {
-        return Horde_Image::contrastColor($this->background(), '#fff', '#000');
+        return method_exists('Horde_Image', 'contrastColor')
+            ? Horde_Image::contrastColor($this->background(), '#fff', '#000')
+            : (Horde_Image::brightness($this->background()) < 128 ? '#fff' : '#000');
     }
 
     /**

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -4626,7 +4626,7 @@ abstract class Kronolith_Event
         }
 
         if ($icons && $prefs->getValue('show_icons')) {
-            $icon_color = Horde_Image::brightness($this->_backgroundColor) < 128 ? 'fff' : '000';
+            $icon_color = Horde_Image::contrastColor($this->_backgroundColor, 'fff', '000');
             $status = '';
             if ($this->alarm) {
                 if ($this->alarm % 10080 == 0) {

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -4626,7 +4626,9 @@ abstract class Kronolith_Event
         }
 
         if ($icons && $prefs->getValue('show_icons')) {
-            $icon_color = Horde_Image::contrastColor($this->_backgroundColor, 'fff', '000');
+            $icon_color = method_exists('Horde_Image', 'contrastColor')
+                ? Horde_Image::contrastColor($this->_backgroundColor, 'fff', '000')
+                : (Horde_Image::brightness($this->_backgroundColor) < 128 ? 'fff' : '000');
             $status = '';
             if ($this->alarm) {
                 if ($this->alarm % 10080 == 0) {

--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -3580,7 +3580,10 @@ class Kronolith
      */
     public static function foregroundColor($calendar)
     {
-        return Horde_Image::contrastColor(is_string($calendar) ? $calendar : self::backgroundColor($calendar), '#fff', '#000');
+        $bg = is_string($calendar) ? $calendar : self::backgroundColor($calendar);
+        return method_exists('Horde_Image', 'contrastColor')
+            ? Horde_Image::contrastColor($bg, '#fff', '#000')
+            : (Horde_Image::brightness($bg) < 128 ? '#fff' : '#000');
     }
 
     /**

--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -3580,7 +3580,7 @@ class Kronolith
      */
     public static function foregroundColor($calendar)
     {
-        return Horde_Image::brightness(is_string($calendar) ? $calendar : self::backgroundColor($calendar)) < 128 ? '#fff' : '#000';
+        return Horde_Image::contrastColor(is_string($calendar) ? $calendar : self::backgroundColor($calendar), '#fff', '#000');
     }
 
     /**

--- a/test/Kronolith/Unit/ForegroundColorTest.php
+++ b/test/Kronolith/Unit/ForegroundColorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (GPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/gpl.
+ *
+ * @author     Torben Dannhauer <torben@dannhauer.de>
+ * @category   Horde
+ * @package    Kronolith
+ * @subpackage UnitTests
+ * @license    http://www.horde.org/licenses/gpl GPL
+ */
+
+/**
+ * Tests calendar foreground color selection (WCAG contrast vs legacy brightness).
+ *
+ * @covers Kronolith::foregroundColor
+ */
+class Kronolith_Unit_ForegroundColorTest extends PHPUnit\Framework\TestCase
+{
+    /**
+     * @dataProvider foregroundColorProvider
+     */
+    public function testForegroundColor(string $background, string $expected): void
+    {
+        if (!method_exists('Horde_Image', 'contrastColor')) {
+            $this->markTestSkipped('Requires Horde_Image::contrastColor() from horde/Image#8');
+        }
+
+        $this->assertSame($expected, Kronolith::foregroundColor($background));
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public function foregroundColorProvider(): array
+    {
+        return [
+            'bright magenta prefers black' => ['#fb00ec', '#000'],
+            'shorthand magenta prefers black' => ['#f0e', '#000'],
+            'blue prefers white' => ['#0000ff', '#fff'],
+            'dark green prefers white' => ['#008000', '#fff'],
+            'white background prefers black' => ['#ffffff', '#000'],
+            'black background prefers white' => ['#000000', '#fff'],
+            'mid gray prefers black' => ['#808080', '#000'],
+        ];
+    }
+
+    public function testForegroundColorUsesWcagNotBrightnessForMagenta(): void
+    {
+        if (!method_exists('Horde_Image', 'contrastColor')) {
+            $this->markTestSkipped('Requires Horde_Image::contrastColor() from horde/Image#8');
+        }
+
+        $background = '#fb00ec';
+        $legacy = Horde_Image::brightness($background) < 128 ? '#fff' : '#000';
+
+        $this->assertSame('#fff', $legacy);
+        $this->assertSame('#000', Kronolith::foregroundColor($background));
+    }
+
+    public function testCalendarForegroundMatchesForegroundColor(): void
+    {
+        if (!method_exists('Horde_Image', 'contrastColor')) {
+            $this->markTestSkipped('Requires Horde_Image::contrastColor() from horde/Image#8');
+        }
+
+        $calendar = new Kronolith_Stub_ForegroundCalendar(['background' => '#fb00ec']);
+
+        $this->assertSame(Kronolith::foregroundColor('#fb00ec'), $calendar->foreground());
+    }
+
+    public function testEventIconColorCandidatesWithoutHash(): void
+    {
+        if (!method_exists('Horde_Image', 'contrastColor')) {
+            $this->markTestSkipped('Requires Horde_Image::contrastColor() from horde/Image#8');
+        }
+
+        $background = '#fb00ec';
+        $iconColor = Horde_Image::contrastColor($background, 'fff', '000');
+
+        $this->assertSame('000', $iconColor);
+        $this->assertSame(
+            ltrim(Kronolith::foregroundColor($background), '#'),
+            $iconColor
+        );
+    }
+
+    public function testLegacyBrightnessFallback(): void
+    {
+        $background = '#0000ff';
+        $expected = Horde_Image::brightness($background) < 128 ? '#fff' : '#000';
+
+        if (method_exists('Horde_Image', 'contrastColor')) {
+            $this->assertSame($expected, Horde_Image::contrastColor($background, '#fff', '#000'));
+        }
+
+        $this->assertSame('#fff', $expected);
+    }
+}
+
+/**
+ * Minimal calendar stub for foreground() tests.
+ */
+class Kronolith_Stub_ForegroundCalendar extends Kronolith_Calendar
+{
+    public function name()
+    {
+        return 'test';
+    }
+
+    public function display()
+    {
+        return 'Test';
+    }
+}


### PR DESCRIPTION
Calendar text and icon foreground colors were chosen by thresholding
`Horde_Image::brightness()` (legacy YIQ). For some saturated backgrounds this
picks the **lower-contrast** foreground — e.g. white text on bright magenta
`#fb00ec` has a WCAG contrast ratio of only **3.33**, below the AA minimum of
4.5, so the text is hard to read.

## Change

Switch the three PHP call sites to `Horde_Image::contrastColor()`, which
compares the actual WCAG contrast ratio of both candidate colors:

- `Kronolith::foregroundColor()`
- `Kronolith_Calendar::foreground()`
- `Kronolith_Event` icon color

Add a matching JS helper `KronolithCore.contrastColor()` for the live color
preview in the calendar dialog, so client and server agree.

For `#fb00ec`, foreground is now black (ratio 6.31) instead of white.

## Dependency

Requires horde/Image#8, which adds `contrastColor()` and
`relativeLuminance()`. Existing return values are unchanged for colors that
were already correct, so this is backward compatible.

## Testing

Verified on a live H6 dev instance: a magenta calendar now renders readable
(black) text; previously-correct colors (blue, dark green → white) are
unchanged.
