### PR TITLE
fix(kronolith): guard EAS sync against invalid timezone blobs

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -2110,7 +2110,15 @@ abstract class Kronolith_Event
                 !empty($this->timezone) ? $this->timezone : date_default_timezone_get()
             );
         } else {
-            $tz = !$message->isGhosted('timezone') ? $message->getTimezone() : $this->timezone;
+            if (!$message->isGhosted('timezone') && !empty($message->timezone)) {
+                try {
+                    $tz = $message->getTimezone();
+                } catch (Horde_Mapi_Exception $e) {
+                    $tz = $this->timezone;
+                }
+            } else {
+                $tz = $this->timezone;
+            }
             if (empty($tz)) {
                 $tz = date_default_timezone_get();
             }


### PR DESCRIPTION
## Summary
- Guard the main EAS appointment import path against empty or invalid timezone blobs
- Fall back to the series timezone when `getTimezone()` raises `Horde_Mapi_Exception`

## Motivation
`_handleEas16Exception()` already avoided `getTimezone()` on empty blobs, but the standard import path at `fromActiveSyncMessage()` still called it unconditionally. Invalid timezone data from iOS clients triggered PHP warnings via `horde/mapi` before this fallback could apply.

Pairs with horde/Mapi PR validating blobs in `getOffsetsFromSyncTZ()`.

## Changes
- Mirror the existing EAS 16.0 exception timezone handling in the non-all-day import branch

## Test plan
- [ ] ActiveSync calendar sync from iOS with recurring-series exception MODIFY
- [ ] Verify no `unpack()` warnings in Horde log for invalid timezone blobs
- [ ] Confirm events keep the series timezone when the client omits or sends bad timezone data
