### PR TITLE
refactor(kronolith): pass series timezone fallback to EAS getTimezone()

### DIFF
--- a/lib/Event.php
+++ b/lib/Event.php
@@ -1958,15 +1958,7 @@ abstract class Kronolith_Event
         }
 
         // EAS 16.0 exception MODIFY often omits Timezone; use the series tz.
-        if (!$message->isGhosted('timezone') && !empty($message->timezone)) {
-            try {
-                $tz = $message->getTimezone();
-            } catch (Horde_Mapi_Exception $e) {
-                $tz = $this->timezone;
-            }
-        } else {
-            $tz = $this->timezone;
-        }
+        $tz = $message->getTimezone($this->timezone ?: date_default_timezone_get());
         if (empty($tz)) {
             $tz = date_default_timezone_get();
         }
@@ -2110,7 +2102,7 @@ abstract class Kronolith_Event
                 !empty($this->timezone) ? $this->timezone : date_default_timezone_get()
             );
         } else {
-            $tz = !$message->isGhosted('timezone') ? $message->getTimezone() : $this->timezone;
+            $tz = $message->getTimezone($this->timezone ?: date_default_timezone_get());
             if (empty($tz)) {
                 $tz = date_default_timezone_get();
             }


### PR DESCRIPTION
## Summary
- Pass the series timezone as fallback to `Appointment::getTimezone()`
- Remove duplicated empty-blob / exception guards from Kronolith

## Motivation
Per review feedback on #68, invalid MAPI timezone handling belongs in `horde/activesync`, not the consuming app. With `Appointment::getTimezone($fallback)`, Kronolith only supplies the series timezone it already knows.

Requires horde/ActiveSync PR adding the fallback parameter (and horde/Mapi blob validation).

## Changes
- `_handleEas16Exception()` and `fromActiveSyncMessage()` use `getTimezone($this->timezone ?: date_default_timezone_get())`

## Test plan
- [ ] ActiveSync calendar sync from iOS with recurring-series exception MODIFY
- [ ] Confirm exceptions keep the series timezone when the client omits or sends bad timezone data
