### PR TITLE
fix(prefs): Fix missing closing parenthesis in "Basic view only" labels

### DIFF
--- a/config/prefs.php
+++ b/config/prefs.php
@@ -125,7 +125,7 @@ $_prefs['max_events'] = [
 $_prefs['time_between_days'] = [
     'value' => 0,
     'type' => 'checkbox',
-    'desc' => _("Show time of day between each day in week views?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("Show time of day between each day in week views?") . ' (<em>' . _("Basic view only") . '</em>)',
 ];
 
 // what day does the week start with
@@ -145,7 +145,7 @@ $_prefs['day_hour_start'] = [
     'value' => 16,
     'type' => 'enum',
     'enum' => [],
-    'desc' => _("What time should day and week views start, when there are no earlier events?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("What time should day and week views start, when there are no earlier events?") . ' (<em>' . _("Basic view only") . '</em>)',
     'on_init' => function ($ui) {
         $enum = [];
         $fmt = $GLOBALS['prefs']->getValue('twentyFour')
@@ -164,7 +164,7 @@ $_prefs['day_hour_end'] = [
     'value' => 48,
     'type' => 'enum',
     'enum' => [],
-    'desc' => _("What time should day and week views end, when there are no later events?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("What time should day and week views end, when there are no later events?") . ' (<em>' . _("Basic view only") . '</em>)',
     'on_init' => function ($ui) {
         $enum = [];
         $fmt = $GLOBALS['prefs']->getValue('twentyFour')
@@ -181,14 +181,14 @@ $_prefs['day_hour_end'] = [
 $_prefs['day_hour_force'] = [
     'value' => 0,
     'type' => 'checkbox',
-    'desc' => _("Restrict day and week views to these time slots, even if there <strong>are</strong> earlier or later events?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("Restrict day and week views to these time slots, even if there <strong>are</strong> earlier or later events?") . ' (<em>' . _("Basic view only") . '</em>)',
 ];
 
 // number of slots in each hour:
 $_prefs['slots_per_hour'] = [
     'value' => 1,
     'type' => 'enum',
-    'desc' => _("How long should the time slots on the day and week views be?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("How long should the time slots on the day and week views be?") . ' (<em>' . _("Basic view only") . '</em>)',
     'enum' => [
         4 => _("15 minutes"),
         3 => _("20 minutes"),
@@ -201,7 +201,7 @@ $_prefs['slots_per_hour'] = [
 $_prefs['show_icons'] = [
     'value' => 1,
     'type' => 'checkbox',
-    'desc' => _("Show delete, alarm, and recurrence icons in calendar views?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("Show delete, alarm, and recurrence icons in calendar views?") . ' (<em>' . _("Basic view only") . '</em>)',
 ];
 
 // show event start/end times in the calendar and/or print views?
@@ -223,7 +223,7 @@ $_prefs['show_location'] = [
         'screen' => _("Month, Week, and Day Views"),
         'print' => _("Print Views"),
     ],
-    'desc' => _("Choose the views to show event locations in:") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("Choose the views to show event locations in:") . ' (<em>' . _("Basic view only") . '</em>)',
 ];
 
 // show Free/Busy legend?
@@ -231,14 +231,14 @@ $_prefs['show_location'] = [
 $_prefs['show_fb_legend'] = [
     'value' => 1,
     'type' => 'checkbox',
-    'desc' => _("Show Free/Busy legend?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("Show Free/Busy legend?") . ' (<em>' . _("Basic view only") . '</em>)',
 ];
 
 // collapsed or side by side view
 $_prefs['show_shared_side_by_side'] = [
     'value' => 0,
     'type' => 'checkbox',
-    'desc' => _("Show shared calendars side-by-side?") . ' (<em>' . _("Basic view only") . '</em>',
+    'desc' => _("Show shared calendars side-by-side?") . ' (<em>' . _("Basic view only") . '</em>)',
 ];
 
 // default calendar


### PR DESCRIPTION
Several preference descriptions append the note "(Basic view only)"
using HTML markup, but the closing parenthesis is missing.

This patch adds the missing ")" to make the text consistent and
correctly formatted.