### PR TITLE
fix(kronolith): avoid foreach() on null in permissions form processing

### DIFF
--- a/lib/Kronolith.php
+++ b/lib/Kronolith.php
@@ -2124,7 +2124,7 @@ class Kronolith
         }
 
         // Process user permissions.
-        $u_names = Util::getFormData('u_names');
+        $u_names = Util::getFormData('u_names') ?: [];
         $u_show = Util::getFormData('u_show');
         $u_read = Util::getFormData('u_read');
         $u_edit = Util::getFormData('u_edit');
@@ -2188,7 +2188,7 @@ class Kronolith
         }
 
         // Process group permissions.
-        $g_names = Util::getFormData('g_names');
+        $g_names = Util::getFormData('g_names') ?: [];
         $g_show = Util::getFormData('g_show');
         $g_read = Util::getFormData('g_read');
         $g_edit = Util::getFormData('g_edit');


### PR DESCRIPTION
## Summary
- Fix a `foreach() argument must be of type array|object, null given` PHP error in `Kronolith::readPermsForm()`.

## Motivation
`readPermsForm()` reads `u_names`/`g_names` from POST data via `Util::getFormData()`, which returns `null` when the field was not submitted at all (e.g. the calendar sharing dialog rendered without a users or groups section for the current share). The subsequent `foreach ($g_names as ...)` then raised a PHP error, aborting permission processing for that submission.

## Changes
- Default `u_names` and `g_names` to `[]` when `Util::getFormData()` returns `null`, so an absent field is treated as an empty list instead of erroring.

## Test plan
- [ ] Share a calendar and save permissions with no additional users/groups added — confirm no PHP error is logged and permissions save successfully.
- [ ] Share a calendar with additional users and/or groups added — confirm permissions still save correctly (no regression).
