### PR TITLE
Expose calendar color as a CSS custom property (--cal-color)

### DIFF
--- a/js/kronolith.js
+++ b/js/kronolith.js
@@ -988,6 +988,7 @@ KronolithCore = {
             .store('calendar', id)
             .store('calendarclass', type)
             .setStyle({ backgroundColor: cal.bg, color: cal.fg });
+        calendar.style.setProperty('--cal-color', cal.bg);
         calendar.insert(
             new Element('span', { className: 'horde-resource-refresh-' + cal.fg.substring(1) })
                 .setStyle({ backgroundColor: cal.bg, color: cal.fg })
@@ -1295,13 +1296,13 @@ KronolithCore = {
      */
     addCalendarLegend: function(type, id, cal)
     {
-        $('kronolith-legend').insert(
-            new Element('span')
-                .insert(cal.name.escapeHTML())
-                .store('calendar', id)
-                .store('calendarclass', type)
-                .setStyle({ backgroundColor: cal.bg, color: cal.fg })
-        );
+        var legendItem = new Element('span')
+            .insert(cal.name.escapeHTML())
+            .store('calendar', id)
+            .store('calendarclass', type)
+            .setStyle({ backgroundColor: cal.bg, color: cal.fg });
+        legendItem.style.setProperty('--cal-color', cal.bg);
+        $('kronolith-legend').insert(legendItem);
     },
 
     /**
@@ -1815,6 +1816,7 @@ KronolithCore = {
                 style = { backgroundColor: Kronolith.conf.calendars[calendar[0]][calendar[1]].bg,
                           color: Kronolith.conf.calendars[calendar[0]][calendar[1]].fg };
 
+            div.style.setProperty('--cal-color', Kronolith.conf.calendars[calendar[0]][calendar[1]].bg);
             div.writeAttribute('title', event.value.t);
 
             if (event.value.al) {
@@ -2101,6 +2103,7 @@ KronolithCore = {
                 div = _createElement(event)
                 .setStyle({ backgroundColor: Kronolith.conf.calendars[calendar[0]][calendar[1]].bg,
                             color: Kronolith.conf.calendars[calendar[0]][calendar[1]].fg });
+            div.style.setProperty('--cal-color', Kronolith.conf.calendars[calendar[0]][calendar[1]].bg);
             div.writeAttribute('title', event.value.t);
             if (before) {
                 before.insert({ before: div });
@@ -2123,6 +2126,7 @@ KronolithCore = {
             var div = _createElement(event)
                 .setStyle({ backgroundColor: Kronolith.conf.calendars[calendar[0]][calendar[1]].bg,
                             color: Kronolith.conf.calendars[calendar[0]][calendar[1]].fg });
+            div.style.setProperty('--cal-color', Kronolith.conf.calendars[calendar[0]][calendar[1]].bg);
             this.createAgendaDay(date);
             $('kronolithAgendaDay' + date).insert(div);
             break;
@@ -3996,6 +4000,7 @@ KronolithCore = {
                     if (element.retrieve('calendar') == id) {
                         var link = element.down('.horde-resource-link span');
                         element.setStyle(color);
+                        element.style.setProperty('--cal-color', cal.bg);
                         link.update(cal.name.escapeHTML());
                         this.addShareIcon(cal, element);
                         throw $break;
@@ -4004,6 +4009,7 @@ KronolithCore = {
                 this.kronolithBody.select('div').each(function(el) {
                     if (el.retrieve('calendar') == type + '|' + id) {
                         el.setStyle(color);
+                        el.style.setProperty('--cal-color', cal.bg);
                     }
                 });
                 legendSpan = $('kronolith-legend').select('span')
@@ -4013,6 +4019,7 @@ KronolithCore = {
                     });
                 if (legendSpan) {
                     legendSpan.setStyle(color).update(cal.name.escapeHTML());
+                    legendSpan.style.setProperty('--cal-color', cal.bg);
                 }
                 Kronolith.conf.calendars[type][id] = cal;
             } else {


### PR DESCRIPTION
## Motivation

Kronolith sets each calendar's color directly as an inline `background-color`
(and `color`) on events, the legend and sidebar entries. That inline value is
**not reusable from CSS**: a theme cannot derive tints, tones or borders from it,
because there is no way to read an inline `background-color` back into a
`color-mix()` / `calc()` expression.

As a result, themes are stuck with the flat, fully-saturated calendar color as
the event background. They cannot implement the now-common "event pill" look
(light tinted background + darker same-hue text + colored accent) used by Google
Calendar, Outlook Web and most modern calendar UIs.

## Change

In addition to the existing inline `background-color`/`color`, also expose the
raw calendar color as a CSS custom property `--cal-color` on the same elements:
events (month / week / day / agenda), the print legend, and sidebar
calendar/tasklist entries — including on live recolor (`saveCalendarCallback`),
so themes relying on it update immediately without a reload.

```js
div.style.setProperty('--cal-color', calendarColor);
```

## Why this is safe / non-breaking

- It **only adds** a custom property; the existing `background-color`/`color`
  inline styles are untouched. Default rendering is byte-for-byte identical.
- No existing theme references `--cal-color`, so nothing changes visually
  anywhere unless a theme opts in.
- It gives themes a clean hook to style events by color, e.g.:

  ```css
  .kronolith-event {
    background-color: color-mix(in srgb, var(--cal-color) 14%, white);
    color: color-mix(in srgb, var(--cal-color) 72%, black);
    border-left: 3px solid var(--cal-color);
  }
  ```

## Example

Below: the UPJV theme using `--cal-color` to render events, the legend and the
sidebar as tinted pills — impossible today because the color is locked in an
inline `background-color`. (Screenshot added in a comment.)
